### PR TITLE
Route `initialize` through provider registry and add `UnsupportedProviderError`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export class UnsupportedProviderError extends Error {
   constructor(provider: string) {
     super(`Unsupported provider: ${provider}`);
     this.name = 'UnsupportedProviderError';
+    Object.setPrototypeOf(this, UnsupportedProviderError.prototype);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,6 @@ function resolveDebugOption(options?: InitializeOptions | boolean): boolean | un
 }
 
 export function initialize<T extends keyof TypesMap>(type: T, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<T>;
-export function initialize(type: string, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<keyof TypesMap>;
 export function initialize(type: string, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<keyof TypesMap> {
   if (!Object.prototype.hasOwnProperty.call(providers, type)) {
     throw new UnsupportedProviderError(type);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,37 @@ import Paddle from "./lib/paddle";
 
 export default Askrift;
 
-export function initialize<T extends keyof TypesMap>(type: T, body: VercelRequest | Request, debug?: boolean): Askrift<T> {
-  return new Paddle(body, debug);
+export type InitializeOptions = {
+  debug?: boolean;
+};
+
+type ProviderRequest = VercelRequest | Request;
+type ProviderConstructor<T extends keyof TypesMap> = new (request: ProviderRequest, debug?: boolean) => Askrift<T>;
+
+const providers: { [T in keyof TypesMap]: ProviderConstructor<T> } = {
+  paddle: Paddle,
+};
+
+export class UnsupportedProviderError extends Error {
+  constructor(provider: string) {
+    super(`Unsupported provider: ${provider}`);
+    this.name = 'UnsupportedProviderError';
+  }
+}
+
+function resolveDebugOption(options?: InitializeOptions | boolean): boolean | undefined {
+  if (typeof options === 'boolean') return options;
+  return options?.debug;
+}
+
+export function initialize<T extends keyof TypesMap>(type: T, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<T>;
+export function initialize(type: string, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<keyof TypesMap>;
+export function initialize(type: string, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<keyof TypesMap> {
+  const Provider = providers[type as keyof TypesMap];
+
+  if (!Provider) {
+    throw new UnsupportedProviderError(type);
+  }
+
+  return new Provider(request, resolveDebugOption(options));
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,11 +31,10 @@ function resolveDebugOption(options?: InitializeOptions | boolean): boolean | un
 export function initialize<T extends keyof TypesMap>(type: T, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<T>;
 export function initialize(type: string, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<keyof TypesMap>;
 export function initialize(type: string, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<keyof TypesMap> {
-  const Provider = providers[type as keyof TypesMap];
-
-  if (!Provider) {
+  if (!Object.prototype.hasOwnProperty.call(providers, type)) {
     throw new UnsupportedProviderError(type);
   }
 
+  const Provider = providers[type as keyof TypesMap];
   return new Provider(request, resolveDebugOption(options));
 };

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -98,13 +98,8 @@ export default class Paddle extends Askrift<"paddle"> {
     this.debug(this._req.body);
     const payload = parseBody(this._req.body);
     if (!payload || typeof payload.p_signature !== 'string') return false;
-    if (typeof this._req.body === 'string') {
-      this._req.body = payload;
-    }
 
     this.debug("PADDLE_PUBLIC_KEY", this._pubKey);
-    // Keep the original request body intact for event handlers while verifying
-    // a copy without p_signature, as required by Paddle.
     const { p_signature, ...unsignedPayload } = payload;
     let jsonObj = ksort(unsignedPayload);
     for (let property in jsonObj) {

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -98,8 +98,13 @@ export default class Paddle extends Askrift<"paddle"> {
     this.debug(this._req.body);
     const payload = parseBody(this._req.body);
     if (!payload || typeof payload.p_signature !== 'string') return false;
+    if (typeof this._req.body === 'string') {
+      this._req.body = payload;
+    }
 
     this.debug("PADDLE_PUBLIC_KEY", this._pubKey);
+    // Keep the original request body intact for event handlers while verifying
+    // a copy without p_signature, as required by Paddle.
     const { p_signature, ...unsignedPayload } = payload;
     let jsonObj = ksort(unsignedPayload);
     for (let property in jsonObj) {

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -31,8 +31,8 @@ const payload = {
 function ksort(obj: { [k: string]: any }) {
   const keys = Object.keys(obj).sort();
   let sortedObj: { [k: string]: any } = {};
-  for (let i in keys) {
-    sortedObj[keys[i]] = obj[keys[i]];
+  for (const key of keys) {
+    sortedObj[key] = obj[key];
   }
   return sortedObj;
 }

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -2,8 +2,6 @@ import Askrift, { initialize, UnsupportedProviderError } from '../src';
 import * as crypto from 'crypto';
 import { serialize } from 'php-serialize';
 import { assert } from 'chai';
-import * as crypto from "crypto";
-import { serialize } from 'php-serialize';
 
 const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
   modulusLength: 2048,
@@ -39,8 +37,8 @@ function ksort(obj: { [k: string]: any }) {
 
 function signedPayload(fields: { [k: string]: any }) {
   const jsonObj = ksort({ ...fields });
-  for (let property in jsonObj) {
-    if (jsonObj.hasOwnProperty(property) && (typeof jsonObj[property]) !== "string") {
+  for (const property of Object.keys(jsonObj)) {
+    if ((typeof jsonObj[property]) !== "string") {
       if (Array.isArray(jsonObj[property])) {
         jsonObj[property] = jsonObj[property].toString();
       } else {
@@ -67,13 +65,26 @@ function createReq(method: string, body = signedPayload(payload)): any {
   };
 }
 
+const validPayload = JSON.parse(signedPayload(payload));
+
+const urlEncodedReq = {
+  ...baseReq,
+  method: 'POST',
+  headers: {
+    'content-type': 'application/x-www-form-urlencoded; charset=utf-8'
+  },
+  body: new URLSearchParams(validPayload).toString(),
+};
+
 describe('library works with paddle', function () {
   let askriftPd: Askrift<'paddle'>;
   let askriftBadPd: Askrift<'paddle'>;
+  let askriftUrlEncodedPd: Askrift<'paddle'>;
 
   it('should initalize successfully', (done) => {
     askriftPd = initialize('paddle', createReq('POST'));
     askriftBadPd = initialize('paddle', createReq('GET', JSON.stringify({ ...payload, p_signature: 'badsign' })));
+    askriftUrlEncodedPd = initialize('paddle', urlEncodedReq);
     done();
   });
 

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -148,7 +148,7 @@ describe('provider registry initialization', function () {
 
   it('throws UnsupportedProviderError for unsupported providers', () => {
     assert.throws(
-      () => initialize('stripe', createReq('POST')),
+      () => initialize('stripe' as any, createReq('POST')),
       UnsupportedProviderError,
       'Unsupported provider: stripe'
     );
@@ -156,7 +156,7 @@ describe('provider registry initialization', function () {
 
   it('throws UnsupportedProviderError for unsupported object prototype keys', () => {
     assert.throws(
-      () => initialize('__proto__', createReq('POST')),
+      () => initialize('__proto__' as any, createReq('POST')),
       UnsupportedProviderError,
       'Unsupported provider: __proto__'
     );

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -128,4 +128,12 @@ describe('provider registry initialization', function () {
       'Unsupported provider: stripe'
     );
   });
+
+  it('throws UnsupportedProviderError for unsupported object prototype keys', () => {
+    assert.throws(
+      () => initialize('__proto__', createReq('POST')),
+      UnsupportedProviderError,
+      'Unsupported provider: __proto__'
+    );
+  });
 });

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -1,7 +1,18 @@
-import Askrift, { initialize } from '../src';
-import dotenv from "dotenv";
-dotenv.config({ path: ".env.local" });
+import Askrift, { initialize, UnsupportedProviderError } from '../src';
+import * as crypto from 'crypto';
+import { serialize } from 'php-serialize';
 import { assert } from 'chai';
+
+const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+});
+
+process.env.PADDLE_PUBLIC_KEY = publicKey
+  .export({ type: 'spki', format: 'pem' })
+  .toString()
+  .replace('-----BEGIN PUBLIC KEY-----', '')
+  .replace('-----END PUBLIC KEY-----', '')
+  .replace(/\s+/g, '');
 
 const baseReq: any = {
   query: {},
@@ -10,28 +21,57 @@ const baseReq: any = {
   },
 };
 
-const goodReq: any = {...baseReq, ...{
-  method: 'POST',
-  body: JSON.stringify({
-    "alert_id": "120661188", "alert_name": "subscription_payment_succeeded", "balance_currency": "GBP", "balance_earnings": "990.07", "balance_fee": "99.44", "balance_gross": "570.99", "balance_tax": "213.9", "checkout_id": "7-8ed52238d1752b0-72f9b4c4b7", "country": "AU", "coupon": "Coupon 8", "currency": "GBP", "customer_name": "customer_name", "earnings": "850.26", "email": "mitchell.ollie@example.org", "event_time": "2021-09-10 10:36:39", "fee": "0.77", "initial_payment": "false", "instalments": "3", "marketing_consent": "", "next_bill_date": "2021-09-25", "next_payment_amount": "next_payment_amount", "order_id": "8",
-    "p_signature": "ISCgCM7lyi/mFSGDa3uqssUJCgsHPC6/jXmBDiOl/t10ylzh24+ZSd5MUxqJ7h+0+wJLCk1HqAEg83tSBQ03PeZOC9mcwYnY2LfwksmE9KIyh4csyrQrACTMRBGrUNTh1z38RRQ2x88+8Jd+m5BDNoY4dBmUMf+qHQEhfEkrwjXiePe7JueEnWRClt/zBktihWJXEAH0ok7wZKIX4ZZ+vt4Q4rrKF8mYwqWO9CUtWPhUTYJSpKr/b7bASDY1ii0xQn9D0UYINyZ6Jh7EpkrXj9AMDDnCyaYwj3/NQ1iMmbnbwnThSGZO56KlcydabXZKkI3f0w7kt7LDtf2WvKxZtuHDGPHe1J0ugh6K4jPqOVW2YCePzw0NU5vo/0Y6rrqLyT0WCnPjD0RtedBeR+UFXblBfGsceGP/Z3Je3lcapF9G9a9j50odf0Cq1nN87lXZrqYh6fMIGcEC8myFHGWW/YHIp6HkvQxG3QlK9gtI+QA3ui8y7NirUp4wASPOj5TVBe371JpP8e0R1Fjv0yRKR2jMnw3+NAEQsUG3pGk4ragYMGxfR/+yHzQVpr3m94KoClvtkfQGJTFN10BQxM5mdMBFEQWEwdwwH7uozx2znczZgqVu1bYsyVU3vsY0DY9cxUISG1XHEmBzGXo8SF/hWj0BcdhIbUBNnOXqlJhNpjI=", "passthrough": "Example String", "payment_method": "card", "payment_tax": "0.12", "plan_name": "Example String", "quantity": "21", "receipt_url": "https://my.paddle.com/receipt/8/485212962ae4daf-2e58a66474", "sale_gross": "463.62", "status": "active", "subscription_id": "8", "subscription_payment_id": "7", "subscription_plan_id": "6", "unit_price": "unit_price", "user_id": "4"
-  })
-}};
+const payload = {
+  "alert_id": "120661188", "alert_name": "subscription_payment_succeeded", "balance_currency": "GBP", "balance_earnings": "990.07", "balance_fee": "99.44", "balance_gross": "570.99", "balance_tax": "213.9", "checkout_id": "7-8ed52238d1752b0-72f9b4c4b7", "country": "AU", "coupon": "Coupon 8", "currency": "GBP", "customer_name": "customer_name", "earnings": "850.26", "email": "mitchell.ollie@example.org", "event_time": "2021-09-10 10:36:39", "fee": "0.77", "initial_payment": "false", "instalments": "3", "marketing_consent": "", "next_bill_date": "2021-09-25", "next_payment_amount": "next_payment_amount", "order_id": "8",
+  "passthrough": "Example String", "payment_method": "card", "payment_tax": "0.12", "plan_name": "Example String", "quantity": "21", "receipt_url": "https://my.paddle.com/receipt/8/485212962ae4daf-2e58a66474", "sale_gross": "463.62", "status": "active", "subscription_id": "8", "subscription_payment_id": "7", "subscription_plan_id": "6", "unit_price": "unit_price", "user_id": "4"
+};
 
-const badReq: any = {...baseReq, ...{
-  method: 'GET',
-  body: JSON.stringify({
-    "alert_id": "120661188", "alert_name": "subscription_payment_succeeded", "balance_currency": "GBP", "balance_earnings": "990.07", "balance_fee": "99.44", "balance_gross": "570.99", "balance_tax": "213.9", "checkout_id": "7-8ed52238d1752b0-72f9b4c4b7", "country": "AU", "coupon": "Coupon 8", "currency": "GBP", "customer_name": "customer_name", "earnings": "850.26", "email": "mitchell.ollie@example.org", "event_time": "2021-09-10 10:36:39", "fee": "0.77", "initial_payment": "false", "instalments": "3", "marketing_consent": "", "next_bill_date": "2021-09-25", "next_payment_amount": "next_payment_amount", "order_id": "8",
-    "p_signature": "badsign", "passthrough": "Example String", "payment_method": "card", "payment_tax": "0.12", "plan_name": "Example String", "quantity": "21", "receipt_url": "https://my.paddle.com/receipt/8/485212962ae4daf-2e58a66474", "sale_gross": "463.62", "status": "active", "subscription_id": "8", "subscription_payment_id": "7", "subscription_plan_id": "6", "unit_price": "unit_price", "user_id": "4"
-  })
-}};
+function ksort(obj: { [k: string]: any }) {
+  const keys = Object.keys(obj).sort();
+  let sortedObj: { [k: string]: any } = {};
+  for (let i in keys) {
+    sortedObj[keys[i]] = obj[keys[i]];
+  }
+  return sortedObj;
+}
+
+function signedPayload(fields: { [k: string]: any }) {
+  const jsonObj = ksort({ ...fields });
+  for (let property in jsonObj) {
+    if (jsonObj.hasOwnProperty(property) && (typeof jsonObj[property]) !== "string") {
+      if (Array.isArray(jsonObj[property])) {
+        jsonObj[property] = jsonObj[property].toString();
+      } else {
+        jsonObj[property] = JSON.stringify(jsonObj[property]);
+      }
+    }
+  }
+
+  const signer = crypto.createSign('sha1');
+  signer.update(serialize(jsonObj));
+  signer.end();
+
+  return JSON.stringify({
+    ...fields,
+    p_signature: signer.sign(privateKey, 'base64'),
+  });
+}
+
+function createReq(method: string, body = signedPayload(payload)): any {
+  return {
+    ...baseReq,
+    method,
+    body,
+  };
+}
 
 describe('library works with paddle', function () {
   let askriftPd: Askrift<'paddle'>;
-  let askriftBadPd: Askrift<'paddle'>;;
+  let askriftBadPd: Askrift<'paddle'>;
+
   it('should initalize successfully', (done) => {
-    askriftPd = initialize('paddle', goodReq);
-    askriftBadPd = initialize('paddle', badReq);
+    askriftPd = initialize('paddle', createReq('POST'));
+    askriftBadPd = initialize('paddle', createReq('GET', JSON.stringify({ ...payload, p_signature: 'badsign' })));
     done();
   });
 
@@ -54,5 +94,38 @@ describe('library works with paddle', function () {
     assert.equal(askriftBadPd.validPayload(), false);
     done();
   });
+});
 
-})
+describe('provider registry initialization', function () {
+  it('dispatches paddle through the provider registry', async () => {
+    const askriftPd = initialize('paddle', createReq('POST'));
+
+    assert.equal(askriftPd.validRequest(), true);
+    assert.equal(askriftPd.validPayload(), true);
+    assert.deepInclude(await askriftPd.onPaymentSucceeded(), {
+      alert_name: 'subscription_payment_succeeded',
+      subscription_id: '8',
+    });
+    assert.equal(await askriftPd.onSubscriptionCreated(), null);
+  });
+
+  it('supports the existing boolean debug argument for paddle users', () => {
+    const askriftPd = initialize('paddle', createReq('POST'), true);
+
+    assert.equal(askriftPd.validRequest(), true);
+  });
+
+  it('supports the options object debug argument for paddle users', () => {
+    const askriftPd = initialize('paddle', createReq('POST'), { debug: true });
+
+    assert.equal(askriftPd.validRequest(), true);
+  });
+
+  it('throws UnsupportedProviderError for unsupported providers', () => {
+    assert.throws(
+      () => initialize('stripe', createReq('POST')),
+      UnsupportedProviderError,
+      'Unsupported provider: stripe'
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Replace the hard-coded Paddle construction in `initialize` with a provider registry so new vendors can be added without changing the public entrypoint. 
- Provide a clear, predictable error when a consumer requests an unknown provider. 
- Preserve backward-compatible behavior for existing Paddle users while enabling an options-style debug argument.

### Description
- Introduced a typed `providers` registry mapping `TypesMap` keys to constructors and updated `initialize` to dispatch via that registry (see `src/index.ts`).
- Added `InitializeOptions` and `resolveDebugOption` to support both the historical boolean debug argument and a new options object, keeping Paddle initialization compatible. 
- Added `UnsupportedProviderError` and throw it when `initialize` is called with an unknown provider name. 
- Added and updated tests in `tests/paddle.ts` to generate a valid Paddle key/payload, assert `initialize('paddle', ...)` yields Paddle behavior, validate debug argument compatibility, and assert unsupported provider names fail predictably.

### Testing
- Ran `npm run build` and TypeScript compiled successfully. 
- Ran `npm test` and all tests passed (`9 passing`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28c1206a888329957d6907c4b9e9a7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ralphilius/askrift/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Initialize function now supports provider-based registration for flexible provider selection.
  * Debug option can be passed as either a boolean or an options object for enhanced configuration.

* **Improvements**
  * Added error handling for unsupported provider types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->