### PR TITLE
Add webhook dispatcher API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,107 @@
-A small utilities library to make it easier to handle webhooks from popular subscription services
+A small utilities library to make it easier to handle webhooks from popular subscription services.
 
-**Áskrift** means subscription in Icelandic
+**Áskrift** means subscription in Icelandic.
 
 ```bash
 npm install @ralphilius/askrift # or yarn add @ralphilius/askrift
 ```
 
-### Use on your server
-Example using Vercel/NextJS serverless function
+## Use on your server
+
+Áskrift can still be used with the provider-specific helpers (`validRequest()`,
+`validPayload()`, `onSubscriptionCreated()`, and friends), but new integrations
+can use the webhook dispatcher API:
+
+```ts
+askrift.on(eventName, handler);
+const result = await askrift.handle();
+```
+
+`handle()` validates the request, verifies the payload signature, parses the
+provider event, and invokes matching handlers. It returns a structured result:
+
+```ts
+{
+  verified: boolean;
+  handled: boolean;
+  eventType?: string;
+}
+```
+
+Event handlers receive the parsed payload and a context object that includes the
+normalized event name, the provider-specific event name, and the matched handler
+name. Paddle webhooks support normalized event names such as
+`subscription.created` and provider-specific names such as
+`paddle.subscription_created`.
+
+### Express example
+
+```ts
+import express from 'express';
+import { initialize } from '@ralphilius/askrift';
+
+const app = express();
+
+app.post('/webhooks/paddle', express.urlencoded({ extended: false }), async (req, res) => {
+  const askrift = initialize('paddle', req);
+
+  askrift.on('subscription.created', async (payload, event) => {
+    console.log('New subscription:', payload.subscription_id);
+    console.log('Provider event:', event.providerEventType);
+  });
+
+  askrift.on('paddle.subscription_payment_succeeded', async (payload) => {
+    console.log('Payment succeeded:', payload.subscription_payment_id);
+  });
+
+  const result = await askrift.handle();
+
+  if (!result.verified) return res.status(403).json(result);
+  if (!result.handled) return res.status(202).json(result);
+
+  return res.status(200).json(result);
+});
+```
+
+### Next.js API route example
+
+```ts
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { initialize } from '@ralphilius/askrift';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const askrift = initialize('paddle', req);
+
+  askrift.on('subscription.created', async (payload) => {
+    console.log('New subscription:', payload.subscription_id);
+  });
+
+  askrift.on('paddle.subscription_cancelled', async (payload) => {
+    console.log('Subscription cancelled:', payload.subscription_id);
+  });
+
+  const result = await askrift.handle();
+
+  if (!result.verified) return res.status(403).json(result);
+
+  return res.status(result.handled ? 200 : 202).json(result);
+}
+```
+
+### Legacy provider-specific helper example
+
 ```js
-import Askrift from '@ralphilius/askrift'
+import { initialize } from '@ralphilius/askrift';
 
 module.exports = (req, res) => {
-  const askrift = Askrift.initialize("paddle", {
-    method: req.method,
-    headers: req.headers,
-    body: req.body,
-  });
-  if(askrift.validRequest()){
-    if(askrift.validPayload()){
+  const askrift = initialize('paddle', req);
+
+  if (askrift.validRequest()) {
+    if (askrift.validPayload()) {
       askrift.onSubscriptionCreated().then(subscription => {
         // Handle subscription_created event
-      })
-    // Handle other events
+      });
+      // Handle other events
     } else {
       // Invalid body, possibly leak of webhooks URL?
       res.status(403).end();
@@ -30,11 +109,11 @@ module.exports = (req, res) => {
   } else {
     res.status(400).end();
   }
-}
-
+};
 ```
 
-### Supported Services
- - Paddle
- - Stripe (Coming soon)
- - Gumroad (Coming soon)
+## Supported Services
+
+- Paddle
+- Stripe (Coming soon)
+- Gumroad (Coming soon)

--- a/README.md
+++ b/README.md
@@ -25,8 +25,14 @@ provider event, and invokes matching handlers. It returns a structured result:
   verified: boolean;
   handled: boolean;
   eventType?: string;
+  errors?: Error[];
 }
 ```
+
+`handled` is `true` only when at least one matching handler was invoked AND none
+of them threw. If any registered handler rejects, `handle()` catches the error,
+records it in `result.errors`, and returns `handled: false` so callers can map
+that to a 5xx response (instead of silently acknowledging a failed side effect).
 
 Event handlers receive the parsed payload and a context object that includes the
 normalized event name, the provider-specific event name, and the matched handler

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ app.post('/webhooks/paddle', express.urlencoded({ extended: false }), async (req
   const result = await askrift.handle();
 
   if (!result.verified) return res.status(403).json(result);
-  if (!result.handled) return res.status(202).json(result);
+  if (!result.handled) return res.status(500).json(result);
 
   return res.status(200).json(result);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import { VercelRequest } from "@vercel/node";
 import { Request } from 'express';
-import Askrift from "./lib/askrift";
+import Askrift, { AskriftEventContext, AskriftEventHandler, AskriftHandleResult, AskriftParsedEvent } from "./lib/askrift";
 import Paddle from "./lib/paddle";
 
 export default Askrift;
 export { Paddle };
+export { AskriftEventContext, AskriftEventHandler, AskriftHandleResult, AskriftParsedEvent };
 export * from "./types/events";
 export type { PaddleSubscriptionEvents } from "./lib/paddle";
 

--- a/src/lib/askrift.ts
+++ b/src/lib/askrift.ts
@@ -16,15 +16,112 @@ type ProviderEvents<Events> = Events extends string
 type ProviderEventPayload<Events, TType extends SubscriptionEventType> =
   TType extends keyof ProviderEvents<Events> ? ProviderEvents<Events>[TType] : NormalizedEventByType<TType>;
 
+export type AskriftHandleResult = {
+  verified: boolean;
+  handled: boolean;
+  eventType?: string;
+  errors?: Error[];
+};
+
+export type AskriftEventContext<EventPayload = any> = {
+  eventType: string;
+  matchedEventName: string;
+  payload: EventPayload;
+  provider?: string;
+  providerEventType?: string;
+};
+
+export type AskriftEventHandler<EventPayload = any> = (
+  payload: EventPayload,
+  context: AskriftEventContext<EventPayload>
+) => void | Promise<void>;
+
+export type AskriftParsedEvent<EventPayload = any> = {
+  eventType: string;
+  payload: EventPayload;
+  provider?: string;
+  providerEventType?: string;
+  aliases?: string[];
+};
+
 export default abstract class Askrift<Events extends ProviderEventMap | string = Record<SubscriptionEventType, NormalizedSubscriptionEvent>> {
   private _debug: boolean;
+  private _handlers: Map<string, AskriftEventHandler[]>;
 
   constructor(debug?: boolean) {
     this._debug = debug || false;
+    this._handlers = new Map();
+  }
+
+  public on<EventPayload = any>(eventName: string, handler: AskriftEventHandler<EventPayload>): this {
+    const normalizedName = this.normalizeEventName(eventName);
+    const handlers = this._handlers.get(normalizedName) || [];
+    handlers.push(handler as AskriftEventHandler);
+    this._handlers.set(normalizedName, handlers);
+    return this;
+  }
+
+  public async handle(): Promise<AskriftHandleResult> {
+    const verified = this.validRequest() && this.validPayload();
+
+    if (!verified) {
+      return { verified: false, handled: false };
+    }
+
+    const event = this.parseProviderEvent();
+
+    if (!event) {
+      return { verified: true, handled: false };
+    }
+
+    const eventNames = this.getDispatchNames(event);
+    const called = new Set<AskriftEventHandler>();
+    const errors: Error[] = [];
+    let handled = false;
+
+    for (const eventName of eventNames) {
+      const handlers = this._handlers.get(eventName);
+
+      if (!handlers || handlers.length === 0) continue;
+
+      handled = true;
+      for (const handler of handlers) {
+        if (called.has(handler)) continue;
+        called.add(handler);
+        try {
+          await handler(event.payload, {
+            eventType: event.eventType,
+            matchedEventName: eventName,
+            payload: event.payload,
+            provider: event.provider,
+            providerEventType: event.providerEventType,
+          });
+        } catch (error) {
+          errors.push(error instanceof Error ? error : new Error(String(error)));
+          this.debug('Askrift handler threw:', error);
+        }
+      }
+    }
+
+    return {
+      verified: true,
+      handled: errors.length === 0 && handled,
+      eventType: event.eventType,
+      ...(errors.length > 0 ? { errors } : {}),
+    };
   }
 
   public debug(msg: any, ...optionalParams: any[]) {
     if (this._debug) console.log(msg, ...optionalParams);
+  }
+
+  protected normalizeEventName(eventName: string): string {
+    return eventName.trim().toLowerCase();
+  }
+
+  private getDispatchNames(event: AskriftParsedEvent): string[] {
+    const names = [event.eventType, ...(event.aliases || [])];
+    return Array.from(new Set(names.map((eventName) => this.normalizeEventName(eventName))));
   }
 
   abstract validRequest(): boolean;
@@ -42,6 +139,10 @@ export default abstract class Askrift<Events extends ProviderEventMap | string =
       return Promise.resolve(null);
     }
     return Promise.resolve(this.toNormalizedEvent());
+  }
+
+  protected parseProviderEvent(): AskriftParsedEvent | null {
+    throw new Error("parseProviderEvent() must be implemented by a subclass");
   }
 
   protected async getProviderEvent<TType extends SubscriptionEventType>(

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -2,7 +2,7 @@ import { VercelRequest } from "@vercel/node";
 import { Request } from 'express';
 import * as crypto from "crypto";
 import { serialize } from 'php-serialize';
-import Askrift from "./askrift";
+import Askrift, { AskriftParsedEvent } from "./askrift";
 import {
   SubscriptionCancelled,
   SubscriptionCreated,
@@ -79,6 +79,10 @@ function parseBody(body: any): PaddlePayload | null {
 
     return Object.keys(payload).length > 0 ? payload : null;
   }
+}
+
+function normalizePaddleEventName(alertName: string): string {
+  return alertName.replace(/_/g, '.');
 }
 
 export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
@@ -257,5 +261,23 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     const result = this.verify() ? this.toNormalizedEvent() : null;
     this._parsedEventPromise = Promise.resolve(result);
     return this._parsedEventPromise;
+  }
+
+  protected parseProviderEvent(): AskriftParsedEvent | null {
+    if (!this._parsedBody) return null;
+
+    const body = this._parsedBody;
+    if (typeof body.alert_name !== 'string') return null;
+
+    const providerEventType = body.alert_name;
+    const eventType = normalizePaddleEventName(providerEventType);
+
+    return {
+      eventType,
+      payload: body,
+      provider: 'paddle',
+      providerEventType,
+      aliases: [`paddle.${providerEventType}`],
+    };
   }
 }

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -62,6 +62,10 @@ function normaliseContentType(contentType: string | string[] | undefined): strin
   return value?.split(';')[0].trim().toLowerCase() || '';
 }
 
+function normalizePaddleEventName(alertName: string): string {
+  return alertName.replace(/_/g, '.');
+}
+
 function parseBody(body: any): PaddlePayload | null {
   if (isObject(body) && !Array.isArray(body)) return body;
   if (typeof body !== 'string') return null;
@@ -79,10 +83,6 @@ function parseBody(body: any): PaddlePayload | null {
 
     return Object.keys(payload).length > 0 ? payload : null;
   }
-}
-
-function normalizePaddleEventName(alertName: string): string {
-  return alertName.replace(/_/g, '.');
 }
 
 export default class Paddle extends Askrift<PaddleSubscriptionEvents> {

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -162,3 +162,54 @@ describe('provider registry initialization', function () {
     );
   });
 });
+
+describe('handle() propagates handler failures', function () {
+  it('reports a thrown handler error and returns handled: false', async () => {
+    const askriftPd = initialize('paddle', createReq('POST'));
+    const boom = new Error('handler exploded');
+
+    askriftPd.on('subscription.payment.succeeded', () => {
+      throw boom;
+    });
+
+    const result = await askriftPd.handle();
+
+    assert.equal(result.verified, true);
+    assert.equal(result.handled, false);
+    assert.equal(result.eventType, 'subscription.payment.succeeded');
+    assert.isArray(result.errors);
+    assert.lengthOf(result.errors!, 1);
+    assert.strictEqual(result.errors![0], boom);
+  });
+
+  it('reports an async rejection and returns handled: false', async () => {
+    const askriftPd = initialize('paddle', createReq('POST'));
+
+    askriftPd.on('subscription.payment.succeeded', async () => {
+      throw new Error('async boom');
+    });
+
+    const result = await askriftPd.handle();
+
+    assert.equal(result.handled, false);
+    assert.isArray(result.errors);
+    assert.lengthOf(result.errors!, 1);
+    assert.instanceOf(result.errors![0], Error);
+    assert.equal(result.errors![0].message, 'async boom');
+  });
+
+  it('returns handled: true and no errors when all handlers succeed', async () => {
+    const askriftPd = initialize('paddle', createReq('POST'));
+    let called = 0;
+
+    askriftPd.on('subscription.payment.succeeded', () => {
+      called += 1;
+    });
+
+    const result = await askriftPd.handle();
+
+    assert.equal(called, 1);
+    assert.equal(result.handled, true);
+    assert.isUndefined(result.errors);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a generic webhook dispatcher so integrations can register handlers with `on(eventName, handler)` and process provider webhooks in a unified way.
- Support normalized event names (e.g. `subscription.created`) alongside provider-specific names (e.g. `paddle.subscription_created`) so handlers can match either form.
- Ensure a single `handle()` entrypoint validates/verifies the payload, parses the provider event, invokes matching handlers, and returns a stable result object.

### Description
- Add dispatcher types and runtime to the base API in `src/lib/askrift.ts`, including `on(eventName, handler)`, `handle()` and the result shape `AskriftHandleResult`.
- Implement event name normalization, dispatch alias resolution, and handler invocation with a context object (`AskriftEventContext`) in `src/lib/askrift.ts`.
- Add Paddle parsing and aliasing in `src/lib/paddle.ts` so `alert_name` is converted to normalized names (e.g. `subscription.created`) and provider aliases (e.g. `paddle.subscription_created`).
- Harden Paddle payload verification to copy/validate the body and fail safely for malformed payloads without mutating the original request.
- Export dispatcher-related types from the public entrypoint in `src/index.ts` and document the new dispatcher with Express and Next.js examples in `README.md`.

### Testing
- Ran `npm run build` successfully to compile TypeScript artifacts.
- Executed a smoke test that instantiated a fake `Askrift` subclass, registered handlers with `on(...)`, and validated `handle()` invoked both normalized and provider alias handlers; the smoke test passed.
- Ran `npm test` in this environment but it failed because `PADDLE_PUBLIC_KEY` is not configured, which prevents the existing Paddle signature tests from initializing (expected in CI with credentials).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28c12d714c83299b7d5ea292a6ff66)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ralphilius/askrift/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->