### PR TITLE
Add Paddle initialization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,59 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 ```
 
+### Explicit configuration
+Pass Paddle configuration directly to `initialize()` with an options object. `publicKey` can be either a full PEM public key or the body of the key without `-----BEGIN PUBLIC KEY-----` / `-----END PUBLIC KEY-----` headers.
+
+```js
+import { initialize } from '@ralphilius/askrift'
+
+module.exports = (req, res) => {
+  const askrift = initialize('paddle', req, {
+    publicKey: process.env.PADDLE_PUBLIC_KEY,
+    debug: process.env.NODE_ENV !== 'production',
+  });
+
+  if(askrift.validRequest()){
+    if(askrift.validPayload()){
+      askrift.onSubscriptionCreated().then(subscription => {
+        // Handle subscription_created event
+      })
+    // Handle other events
+    } else {
+      // Invalid body, possibly leak of webhooks URL?
+      res.status(403).end();
+    }
+  } else {
+    res.status(400).end();
+  }
+}
+```
+
+### Environment variable fallback
+For backward compatibility, Áskrift will still read `process.env.PADDLE_PUBLIC_KEY` when you do not pass `publicKey` in the options object.
+
+```js
+import { initialize } from '@ralphilius/askrift'
+
+module.exports = (req, res) => {
+  const askrift = initialize('paddle', req);
+
+  if(askrift.validRequest()){
+    if(askrift.validPayload()){
+      askrift.onSubscriptionCreated().then(subscription => {
+        // Handle subscription_created event
+      })
+    // Handle other events
+    } else {
+      // Invalid body, possibly leak of webhooks URL?
+      res.status(403).end();
+    }
+  } else {
+    res.status(400).end();
+  }
+}
+```
+
 ### Legacy provider-specific helper example
 
 ```js

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { VercelRequest } from "@vercel/node";
 import { Request } from 'express';
 import Askrift, { AskriftEventContext, AskriftEventHandler, AskriftHandleResult, AskriftParsedEvent } from "./lib/askrift";
-import Paddle from "./lib/paddle";
+import Paddle, { PaddleOptions } from "./lib/paddle";
 
 export default Askrift;
 export { Paddle };
@@ -14,12 +14,10 @@ export type TypesMap = {
   paddle: Paddle;
 };
 
-export type InitializeOptions = {
-  debug?: boolean;
-};
+export type InitializeOptions = PaddleOptions;
 
 type ProviderRequest = VercelRequest | Request;
-type ProviderConstructor = new (request: ProviderRequest, debug?: boolean) => Askrift<any>;
+type ProviderConstructor = new (request: ProviderRequest, options?: InitializeOptions | boolean) => Askrift<any>;
 
 const providers: Record<string, ProviderConstructor> = {
   paddle: Paddle,
@@ -33,11 +31,6 @@ export class UnsupportedProviderError extends Error {
   }
 }
 
-function resolveDebugOption(options?: InitializeOptions | boolean): boolean | undefined {
-  if (typeof options === 'boolean') return options;
-  return options?.debug;
-}
-
 export function initialize<T extends keyof TypesMap>(type: T, request: ProviderRequest, options?: InitializeOptions | boolean): TypesMap[T];
 export function initialize(type: string, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<any> {
   if (!Object.prototype.hasOwnProperty.call(providers, type)) {
@@ -45,5 +38,5 @@ export function initialize(type: string, request: ProviderRequest, options?: Ini
   }
 
   const Provider = providers[type];
-  return new Provider(request, resolveDebugOption(options));
+  return new Provider(request, options);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,9 @@ export type TypesMap = {
 export type InitializeOptions = PaddleOptions;
 
 type ProviderRequest = VercelRequest | Request;
-type ProviderConstructor = new (request: ProviderRequest, options?: InitializeOptions | boolean) => Askrift<any>;
+type ProviderConstructor<T extends keyof TypesMap> = new (request: ProviderRequest, options?: PaddleOptions | boolean) => Askrift<T>;
 
-const providers: Record<string, ProviderConstructor> = {
+const providers: { [T in keyof TypesMap]: ProviderConstructor<T> } = {
   paddle: Paddle,
 };
 
@@ -31,12 +31,17 @@ export class UnsupportedProviderError extends Error {
   }
 }
 
-export function initialize<T extends keyof TypesMap>(type: T, request: ProviderRequest, options?: InitializeOptions | boolean): TypesMap[T];
-export function initialize(type: string, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<any> {
+function resolveOptions(options?: InitializeOptions | boolean): PaddleOptions | boolean | undefined {
+  if (typeof options === 'boolean') return options;
+  return options;
+}
+
+export function initialize<T extends keyof TypesMap>(type: T, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<T>;
+export function initialize(type: string, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<keyof TypesMap> {
   if (!Object.prototype.hasOwnProperty.call(providers, type)) {
     throw new UnsupportedProviderError(type);
   }
 
-  const Provider = providers[type];
-  return new Provider(request, options);
+  const Provider = providers[type as keyof TypesMap];
+  return new Provider(request, resolveOptions(options));
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export { Paddle };
 export { verifyPaddleSignature } from "./lib/paddle";
 export { AskriftEventContext, AskriftEventHandler, AskriftHandleResult, AskriftParsedEvent };
 export * from "./types/events";
-export type { PaddleSubscriptionEvents } from "./lib/paddle";
+export type { PaddleOptions, PaddleSubscriptionEvents } from "./lib/paddle";
 
 export type TypesMap = {
   paddle: Paddle;
@@ -17,7 +17,7 @@ export type TypesMap = {
 export type InitializeOptions = PaddleOptions;
 
 type ProviderRequest = VercelRequest | Request;
-type ProviderConstructor<T extends keyof TypesMap> = new (request: ProviderRequest, options?: PaddleOptions | boolean) => Askrift<T>;
+type ProviderConstructor<T extends keyof TypesMap> = new (request: ProviderRequest, options?: PaddleOptions | boolean) => TypesMap[T];
 
 const providers: { [T in keyof TypesMap]: ProviderConstructor<T> } = {
   paddle: Paddle,
@@ -36,8 +36,8 @@ function resolveOptions(options?: InitializeOptions | boolean): PaddleOptions | 
   return options;
 }
 
-export function initialize<T extends keyof TypesMap>(type: T, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<T>;
-export function initialize(type: string, request: ProviderRequest, options?: InitializeOptions | boolean): Askrift<keyof TypesMap> {
+export function initialize<T extends keyof TypesMap>(type: T, request: ProviderRequest, options?: InitializeOptions | boolean): TypesMap[T];
+export function initialize(type: string, request: ProviderRequest, options?: InitializeOptions | boolean): TypesMap[keyof TypesMap] {
   if (!Object.prototype.hasOwnProperty.call(providers, type)) {
     throw new UnsupportedProviderError(type);
   }

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -148,7 +148,7 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     const paddleOptions = typeof options === 'boolean' ? { debug: options } : options;
     super(paddleOptions.debug);
 
-    const publicKey = paddleOptions.publicKey || process.env.PADDLE_PUBLIC_KEY;
+    const publicKey = paddleOptions.publicKey !== undefined ? paddleOptions.publicKey : process.env.PADDLE_PUBLIC_KEY;
     if (!publicKey) throw new Error("Paddle public key is required (provide via options.publicKey or PADDLE_PUBLIC_KEY environment variable)");
 
     this._req = req;

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -28,6 +28,9 @@ export type PaddleOptions = {
 };
 
 function normalizePublicKey(publicKey: string): string {
+  if (!publicKey || !publicKey.trim()) {
+    throw new Error("Public key cannot be empty");
+  }
   const normalized = publicKey.replace(/\\n/g, '\n');
   if (normalized.includes('-----BEGIN PUBLIC KEY-----')) {
     return normalized;
@@ -146,7 +149,7 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     super(paddleOptions.debug);
 
     const publicKey = paddleOptions.publicKey || process.env.PADDLE_PUBLIC_KEY;
-    if (!publicKey) throw "PADDLE_PUBLIC_KEY is required";
+    if (!publicKey) throw new Error("Paddle public key is required (provide via options.publicKey or PADDLE_PUBLIC_KEY environment variable)");
 
     this._req = req;
     this._pubKey = normalizePublicKey(publicKey);

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -20,6 +20,22 @@ import { isObject } from "./utils";
 
 type PaddlePayload = { [k: string]: any };
 
+export type PaddleOptions = {
+  /** Paddle public key, with or without PEM headers. Falls back to PADDLE_PUBLIC_KEY. */
+  publicKey?: string;
+  /** Enable debug logging. */
+  debug?: boolean;
+};
+
+function normalizePublicKey(publicKey: string): string {
+  const normalized = publicKey.replace(/\\n/g, '\n');
+  if (normalized.includes('-----BEGIN PUBLIC KEY-----')) {
+    return normalized;
+  }
+
+  return `-----BEGIN PUBLIC KEY-----\n${normalized}\n-----END PUBLIC KEY-----`;
+}
+
 export type PaddleSubscriptionEvents = {
   [SUBSCRIPTION_EVENT_TYPES.SubscriptionCreated]: SubscriptionCreated;
   [SUBSCRIPTION_EVENT_TYPES.SubscriptionUpdated]: SubscriptionUpdated;
@@ -125,11 +141,15 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
   private _parsedBody: PaddlePayload | null | undefined;
   private _parsedEventPromise: Promise<NormalizedSubscriptionEvent | null> | null = null;
 
-  constructor(req: VercelRequest | Request, debugged?: boolean) {
-    super(debugged);
-    if (!process.env.PADDLE_PUBLIC_KEY) throw new Error("PADDLE_PUBLIC_KEY is required");
+  constructor(req: VercelRequest | Request, options: PaddleOptions | boolean = {}) {
+    const paddleOptions = typeof options === 'boolean' ? { debug: options } : options;
+    super(paddleOptions.debug);
+
+    const publicKey = paddleOptions.publicKey || process.env.PADDLE_PUBLIC_KEY;
+    if (!publicKey) throw "PADDLE_PUBLIC_KEY is required";
+
     this._req = req;
-    this._pubKey = `-----BEGIN PUBLIC KEY-----\n${process.env.PADDLE_PUBLIC_KEY?.replace(/\\n/g, '\n')}\n-----END PUBLIC KEY-----`;
+    this._pubKey = normalizePublicKey(publicKey);
   }
 
   onSubscriptionCreated(): Promise<SubscriptionCreated | null> {

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -8,12 +8,14 @@ const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
   modulusLength: 2048,
 });
 
-process.env.PADDLE_PUBLIC_KEY = publicKey
+const PUBLIC_KEY_BODY = publicKey
   .export({ type: 'spki', format: 'pem' })
   .toString()
   .replace('-----BEGIN PUBLIC KEY-----', '')
   .replace('-----END PUBLIC KEY-----', '')
   .replace(/\s+/g, '');
+
+process.env.PADDLE_PUBLIC_KEY = PUBLIC_KEY_BODY;
 
 const baseReq: any = {
   query: {},
@@ -122,9 +124,18 @@ const urlEncodedReq = {
 };
 
 describe('library works with paddle', function () {
+  const previousPublicKey = process.env.PADDLE_PUBLIC_KEY;
   let askriftPd: Askrift<'paddle'>;
   let askriftBadPd: Askrift<'paddle'>;
   let askriftUrlEncodedPd: Askrift<'paddle'>;
+
+  after(() => {
+    if (previousPublicKey === undefined) {
+      delete process.env.PADDLE_PUBLIC_KEY;
+    } else {
+      process.env.PADDLE_PUBLIC_KEY = previousPublicKey;
+    }
+  });
 
   it('should initalize successfully', (done) => {
     askriftPd = initialize('paddle', reqFor('POST', JSON.stringify(validPayload), 'application/json'));
@@ -385,5 +396,34 @@ describe('handle() propagates handler failures', function () {
     assert.equal(called, 1);
     assert.equal(result.handled, true);
     assert.isUndefined(result.errors);
+  });
+});
+
+describe('paddle initialization options', function () {
+  const previousPublicKey = process.env.PADDLE_PUBLIC_KEY;
+
+  after(() => {
+    if (previousPublicKey === undefined) {
+      delete process.env.PADDLE_PUBLIC_KEY;
+    } else {
+      process.env.PADDLE_PUBLIC_KEY = previousPublicKey;
+    }
+  });
+
+  it('should initalize successfully with explicit config', (done) => {
+    delete process.env.PADDLE_PUBLIC_KEY;
+    const askriftPd = initialize('paddle', createReq('POST'), { publicKey: PUBLIC_KEY_BODY });
+    const askriftBadPd = initialize('paddle', createReq('GET', JSON.stringify({ ...payload, p_signature: 'badsign' })), { publicKey: PUBLIC_KEY_BODY });
+    assert.equal(askriftPd.validRequest(), true);
+    assert.equal(askriftPd.validPayload(), true);
+    assert.equal(askriftBadPd.validPayload(), false);
+    done();
+  });
+
+  it('should initalize successfully from PADDLE_PUBLIC_KEY env fallback', (done) => {
+    process.env.PADDLE_PUBLIC_KEY = PUBLIC_KEY_BODY;
+    const askriftFromEnv = initialize('paddle', createReq('POST'));
+    assert.equal(askriftFromEnv.validPayload(), true);
+    done();
   });
 });

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -8,6 +8,8 @@ const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
   modulusLength: 2048,
 });
 
+const previousPublicKey = process.env.PADDLE_PUBLIC_KEY;
+
 const PUBLIC_KEY_BODY = publicKey
   .export({ type: 'spki', format: 'pem' })
   .toString()

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -1,4 +1,4 @@
-import Askrift, { initialize, UnsupportedProviderError } from '../src';
+import { initialize, Paddle, UnsupportedProviderError } from '../src';
 import * as crypto from 'crypto';
 import { serialize } from 'php-serialize';
 import { assert } from 'chai';
@@ -127,9 +127,9 @@ const urlEncodedReq = {
 
 describe('library works with paddle', function () {
   const previousPublicKey = process.env.PADDLE_PUBLIC_KEY;
-  let askriftPd: Askrift<'paddle'>;
-  let askriftBadPd: Askrift<'paddle'>;
-  let askriftUrlEncodedPd: Askrift<'paddle'>;
+  let askriftPd: Paddle;
+  let askriftBadPd: Paddle;
+  let askriftUrlEncodedPd: Paddle;
 
   after(() => {
     if (previousPublicKey === undefined) {


### PR DESCRIPTION
### Motivation
- Allow callers to pass explicit Paddle configuration (public key and debug) into `initialize()` and the provider constructor while preserving the existing boolean debug shorthand.
- Maintain backward compatibility by keeping `process.env.PADDLE_PUBLIC_KEY` as a fallback when no explicit `publicKey` is provided.
- Provide clearer usage examples and stronger test coverage for both explicit configuration and the environment fallback.

### Description
- Added a typed `PaddleOptions` interface (`publicKey?: string`, `debug?: boolean`) and a `normalizePublicKey` helper in `src/lib/paddle.ts` to accept either PEM or key body.
- Updated the `Paddle` constructor to accept `options: PaddleOptions | boolean` and to prefer `options.publicKey` with fallback to `process.env.PADDLE_PUBLIC_KEY`.
- Updated the public `initialize()` API in `src/index.ts` to accept the options object and exported `PaddleOptions` for consumers.
- Rewrote `tests/paddle.ts` to generate and verify signed payloads and added test cases that cover explicit `publicKey` usage and the environment variable fallback, and updated `README.md` with examples for both configuration styles.

### Testing
- Ran TypeScript compilation with `./node_modules/.bin/tsc` which succeeded.
- Ran unit tests with `env TS_NODE_COMPILER_OPTIONS='{"module": "commonjs" }' ./node_modules/.bin/mocha -r ts-node/register 'tests/**/*.ts' --exit` which succeeded (`6 passing`).
- Noted that `yarn build && yarn test` failed in this environment due to a Corepack/Yarn lockfile mismatch, but local `tsc` + `mocha` verification passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28c140c698832998fc14d5ad417687)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ralphilius/askrift/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Paddle initialization now supports explicit configuration via `publicKey` option in initialization parameters
  * Added automatic fallback to `PADDLE_PUBLIC_KEY` environment variable when publicKey is not provided

* **Documentation**
  * Updated README with explicit Paddle configuration flow examples and environment variable fallback information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->