### PR TITLE
Add framework-agnostic request adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ npm install @ralphilius/askrift # or yarn add @ralphilius/askrift
 
 ## Use on your server
 
+Áskrift provider logic works with a small internal request shape instead of importing framework-specific request types:
+
+```ts
+type InternalRequest = {
+  method: string;
+  headers: Record<string, string | string[] | undefined>;
+  body: unknown;
+  rawBody?: Buffer | string;
+}
+```
+
+Use an adapter helper to convert the request from your framework before calling `initialize`.
+
 Áskrift can still be used with the provider-specific helpers (`validRequest()`,
 `validPayload()`, `onSubscriptionCreated()`, and friends), but new integrations
 can use the webhook dispatcher API:
@@ -38,18 +51,18 @@ Event handlers receive the parsed payload and a context object that includes the
 normalized event name, the provider-specific event name, and the matched handler
 name. Paddle webhooks support normalized event names such as
 `subscription.created` and provider-specific names such as
-`paddle.subscription_created`.
+`paddle.subscription_payment_succeeded`.
 
 ### Express example
 
 ```ts
 import express from 'express';
-import { initialize } from '@ralphilius/askrift';
+import { initialize, fromExpress } from '@ralphilius/askrift';
 
 const app = express();
 
 app.post('/webhooks/paddle', express.urlencoded({ extended: false }), async (req, res) => {
-  const askrift = initialize('paddle', req);
+  const askrift = initialize('paddle', fromExpress(req));
 
   askrift.on('subscription.created', async (payload, event) => {
     console.log('New subscription:', payload.subscription_id);
@@ -73,10 +86,10 @@ app.post('/webhooks/paddle', express.urlencoded({ extended: false }), async (req
 
 ```ts
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { initialize } from '@ralphilius/askrift';
+import { initialize, fromVercel } from '@ralphilius/askrift';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const askrift = initialize('paddle', req);
+  const askrift = initialize('paddle', fromVercel(req));
 
   askrift.on('subscription.created', async (payload) => {
     console.log('New subscription:', payload.subscription_id);
@@ -98,10 +111,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 Pass Paddle configuration directly to `initialize()` with an options object. `publicKey` can be either a full PEM public key or the body of the key without `-----BEGIN PUBLIC KEY-----` / `-----END PUBLIC KEY-----` headers.
 
 ```js
-import { initialize } from '@ralphilius/askrift'
+import { initialize, fromVercel } from '@ralphilius/askrift'
 
 module.exports = (req, res) => {
-  const askrift = initialize('paddle', req, {
+  const askrift = initialize('paddle', fromVercel(req), {
     publicKey: process.env.PADDLE_PUBLIC_KEY,
     debug: process.env.NODE_ENV !== 'production',
   });
@@ -126,10 +139,10 @@ module.exports = (req, res) => {
 For backward compatibility, Áskrift will still read `process.env.PADDLE_PUBLIC_KEY` when you do not pass `publicKey` in the options object.
 
 ```js
-import { initialize } from '@ralphilius/askrift'
+import { initialize, fromVercel } from '@ralphilius/askrift'
 
 module.exports = (req, res) => {
-  const askrift = initialize('paddle', req);
+  const askrift = initialize('paddle', fromVercel(req));
 
   if(askrift.validRequest()){
     if(askrift.validPayload()){
@@ -147,13 +160,33 @@ module.exports = (req, res) => {
 }
 ```
 
+### Raw/internal request objects
+
+If your framework is not covered by a dedicated helper, use `fromRaw` with the same minimal fields:
+
+```ts
+import { initialize, fromRaw } from '@ralphilius/askrift'
+
+const request = fromRaw({
+  method: 'POST',
+  headers: {
+    'content-type': 'application/x-www-form-urlencoded',
+  },
+  body: webhookBody,
+})
+
+const askrift = initialize('paddle', request)
+```
+
+The built-in adapters normalize header names to lowercase and pass through `body` and optional `rawBody` values.
+
 ### Legacy provider-specific helper example
 
 ```js
-import { initialize } from '@ralphilius/askrift';
+import { initialize, fromVercel } from '@ralphilius/askrift';
 
 module.exports = (req, res) => {
-  const askrift = initialize('paddle', req);
+  const askrift = initialize('paddle', fromVercel(req));
 
   if (askrift.validRequest()) {
     if (askrift.validPayload()) {

--- a/package.json
+++ b/package.json
@@ -11,13 +11,11 @@
     "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'tests/**/*.ts' --exit"
   },
   "dependencies": {
-    "@vercel/node": "^1.12.1",
     "crypto": "^1.0.1",
     "php-serialize": "^4.0.2"
   },
   "devDependencies": {
     "@types/chai": "^4.2.21",
-    "@types/express": "^4.17.13",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.9.1",
     "chai": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'tests/**/*.ts' --exit"
   },
   "dependencies": {
-    "@types/node": "^16.9.1",
     "crypto": "^1.0.1",
     "php-serialize": "^4.0.2"
   },
   "devDependencies": {
     "@types/chai": "^4.2.21",
     "@types/mocha": "^9.0.0",
+    "@types/node": "^16.9.1",
     "chai": "^4.3.4",
     "dotenv": "^10.0.0",
     "mocha": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'tests/**/*.ts' --exit"
   },
   "dependencies": {
+    "@types/node": "^16.9.1",
     "crypto": "^1.0.1",
     "php-serialize": "^4.0.2"
   },
   "devDependencies": {
     "@types/chai": "^4.2.21",
     "@types/mocha": "^9.0.0",
-    "@types/node": "^16.9.1",
     "chai": "^4.3.4",
     "dotenv": "^10.0.0",
     "mocha": "^9.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,15 @@
-import { VercelRequest } from "@vercel/node";
-import { Request } from 'express';
 import Askrift, { AskriftEventContext, AskriftEventHandler, AskriftHandleResult, AskriftParsedEvent } from "./lib/askrift";
 import Paddle, { PaddleOptions } from "./lib/paddle";
+import { fromExpress, fromRaw, fromVercel } from "./lib/request";
+import type { InternalRequest, RequestHeaders } from "./lib/request";
 
 export default Askrift;
 export { Paddle };
 export { verifyPaddleSignature } from "./lib/paddle";
+export { fromExpress, fromRaw, fromVercel };
 export { AskriftEventContext, AskriftEventHandler, AskriftHandleResult, AskriftParsedEvent };
 export * from "./types/events";
+export type { InternalRequest, RequestHeaders } from "./lib/request";
 export type { PaddleOptions, PaddleSubscriptionEvents } from "./lib/paddle";
 
 export type TypesMap = {
@@ -16,8 +18,8 @@ export type TypesMap = {
 
 export type InitializeOptions = PaddleOptions;
 
-type ProviderRequest = VercelRequest | Request;
-type ProviderConstructor<T extends keyof TypesMap> = new (request: ProviderRequest, options?: PaddleOptions | boolean) => TypesMap[T];
+type ProviderRequest = InternalRequest;
+type ProviderConstructor<T extends keyof TypesMap> = new (request: InternalRequest, options?: PaddleOptions | boolean) => TypesMap[T];
 
 const providers: { [T in keyof TypesMap]: ProviderConstructor<T> } = {
   paddle: Paddle,

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -1,5 +1,3 @@
-import { VercelRequest } from "@vercel/node";
-import { Request } from 'express';
 import * as crypto from "crypto";
 import { serialize } from 'php-serialize';
 import Askrift, { AskriftParsedEvent } from "./askrift";
@@ -16,6 +14,8 @@ import {
   SUBSCRIPTION_EVENT_TYPES,
   SubscriptionEventType,
 } from "../types/events";
+import { fromRaw } from "./request";
+import type { InternalRequest } from "./request";
 import { isObject } from "./utils";
 
 type PaddlePayload = { [k: string]: any };
@@ -139,19 +139,19 @@ export function verifyPaddleSignature(payload: unknown, publicKey: string): bool
 }
 
 export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
-  private _req;
+  private _req: InternalRequest;
   private _pubKey: string;
   private _parsedBody: PaddlePayload | null | undefined;
   private _parsedEventPromise: Promise<NormalizedSubscriptionEvent | null> | null = null;
 
-  constructor(req: VercelRequest | Request, options: PaddleOptions | boolean = {}) {
+  constructor(req: InternalRequest, options: PaddleOptions | boolean = {}) {
     const paddleOptions = typeof options === 'boolean' ? { debug: options } : options;
     super(paddleOptions.debug);
 
     const publicKey = paddleOptions.publicKey !== undefined ? paddleOptions.publicKey : process.env.PADDLE_PUBLIC_KEY;
     if (!publicKey) throw new Error("Paddle public key is required (provide via options.publicKey or PADDLE_PUBLIC_KEY environment variable)");
 
-    this._req = req;
+    this._req = fromRaw(req);
     this._pubKey = normalizePublicKey(publicKey);
   }
 

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -23,13 +23,13 @@ type FrameworkRequest = {
   rawBody?: Buffer | string;
 };
 
-function normalizeHeaders(headers: Record<string, HeaderValue> = {}): RequestHeaders {
-  return Object.entries(headers).reduce<RequestHeaders>((normalized, [key, value]) => {
+function normalizeHeaders(headers: Record<string, HeaderValue> | null = {}): RequestHeaders {
+  return Object.entries(headers || {}).reduce<RequestHeaders>((normalized, [key, value]) => {
     const normalizedKey = key.toLowerCase();
 
     if (Array.isArray(value)) {
       normalized[normalizedKey] = value.map(String);
-    } else if (value === undefined) {
+    } else if (value === undefined || value === null) {
       normalized[normalizedKey] = undefined;
     } else {
       normalized[normalizedKey] = String(value);
@@ -49,19 +49,21 @@ export function fromRaw({ method, headers = {}, body, rawBody }: RawRequestInput
 }
 
 export function fromExpress(req: FrameworkRequest): InternalRequest {
+  const safeReq = req || {};
   return fromRaw({
-    method: req.method || '',
-    headers: req.headers,
-    body: req.body,
-    rawBody: req.rawBody,
+    method: safeReq.method || '',
+    headers: safeReq.headers,
+    body: safeReq.body,
+    rawBody: safeReq.rawBody,
   });
 }
 
 export function fromVercel(req: FrameworkRequest): InternalRequest {
+  const safeReq = req || {};
   return fromRaw({
-    method: req.method || '',
-    headers: req.headers,
-    body: req.body,
-    rawBody: req.rawBody,
+    method: safeReq.method || '',
+    headers: safeReq.headers,
+    body: safeReq.body,
+    rawBody: safeReq.rawBody,
   });
 }

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -40,10 +40,15 @@ function normalizeHeaders(headers: Record<string, HeaderValue> | null = {}): Req
 }
 
 export function fromRaw({ method, headers = {}, body, rawBody }: RawRequestInput): InternalRequest {
+  const resolvedBody = body !== undefined
+    ? body
+    : rawBody instanceof Buffer
+      ? rawBody.toString('utf8')
+      : rawBody;
   return {
     method,
     headers: normalizeHeaders(headers),
-    body,
+    body: resolvedBody,
     rawBody,
   };
 }

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -1,0 +1,67 @@
+export type RequestHeaders = Record<string, string | string[] | undefined>;
+
+export type InternalRequest = {
+  method: string;
+  headers: RequestHeaders;
+  body: unknown;
+  rawBody?: Buffer | string;
+};
+
+type HeaderValue = string | number | string[] | undefined;
+
+type RawRequestInput = {
+  method: string;
+  headers?: Record<string, HeaderValue>;
+  body?: unknown;
+  rawBody?: Buffer | string;
+};
+
+type FrameworkRequest = {
+  method?: string;
+  headers?: Record<string, HeaderValue>;
+  body?: unknown;
+  rawBody?: Buffer | string;
+};
+
+function normalizeHeaders(headers: Record<string, HeaderValue> = {}): RequestHeaders {
+  return Object.entries(headers).reduce<RequestHeaders>((normalized, [key, value]) => {
+    const normalizedKey = key.toLowerCase();
+
+    if (Array.isArray(value)) {
+      normalized[normalizedKey] = value.map(String);
+    } else if (value === undefined) {
+      normalized[normalizedKey] = undefined;
+    } else {
+      normalized[normalizedKey] = String(value);
+    }
+
+    return normalized;
+  }, {});
+}
+
+export function fromRaw({ method, headers = {}, body, rawBody }: RawRequestInput): InternalRequest {
+  return {
+    method,
+    headers: normalizeHeaders(headers),
+    body,
+    rawBody,
+  };
+}
+
+export function fromExpress(req: FrameworkRequest): InternalRequest {
+  return fromRaw({
+    method: req.method || '',
+    headers: req.headers,
+    body: req.body,
+    rawBody: req.rawBody,
+  });
+}
+
+export function fromVercel(req: FrameworkRequest): InternalRequest {
+  return fromRaw({
+    method: req.method || '',
+    headers: req.headers,
+    body: req.body,
+    rawBody: req.rawBody,
+  });
+}

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -48,7 +48,7 @@ export function fromRaw({ method, headers = {}, body, rawBody }: RawRequestInput
   };
 }
 
-export function fromExpress(req: FrameworkRequest): InternalRequest {
+function adaptFrameworkRequest(req: FrameworkRequest): InternalRequest {
   const safeReq = req || {};
   return fromRaw({
     method: safeReq.method || '',
@@ -58,12 +58,10 @@ export function fromExpress(req: FrameworkRequest): InternalRequest {
   });
 }
 
+export function fromExpress(req: FrameworkRequest): InternalRequest {
+  return adaptFrameworkRequest(req);
+}
+
 export function fromVercel(req: FrameworkRequest): InternalRequest {
-  const safeReq = req || {};
-  return fromRaw({
-    method: safeReq.method || '',
-    headers: safeReq.headers,
-    body: safeReq.body,
-    rawBody: safeReq.rawBody,
-  });
+  return adaptFrameworkRequest(req);
 }

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -1,4 +1,4 @@
-import { initialize, Paddle, UnsupportedProviderError } from '../src';
+import Askrift, { initialize, fromVercel, Paddle, UnsupportedProviderError } from '../src';
 import * as crypto from 'crypto';
 import { serialize } from 'php-serialize';
 import { assert } from 'chai';
@@ -140,9 +140,9 @@ describe('library works with paddle', function () {
   });
 
   it('should initalize successfully', (done) => {
-    askriftPd = initialize('paddle', reqFor('POST', JSON.stringify(validPayload), 'application/json'));
-    askriftBadPd = initialize('paddle', reqFor('GET', JSON.stringify(invalidPayload), 'application/json'));
-    askriftUrlEncodedPd = initialize('paddle', urlEncodedReq);
+    askriftPd = initialize('paddle', fromVercel(createReq('POST')));
+    askriftBadPd = initialize('paddle', fromVercel(createReq('GET', JSON.stringify({ ...payload, p_signature: 'badsign' }))));
+    askriftUrlEncodedPd = initialize('paddle', fromVercel(urlEncodedReq));
     done();
   });
 
@@ -310,7 +310,7 @@ describe('library works with paddle', function () {
 
 describe('provider registry initialization', function () {
   it('dispatches paddle through the provider registry', async () => {
-    const askriftPd = initialize('paddle', reqFor('POST', JSON.stringify(validPayload), 'application/json'));
+    const askriftPd = initialize('paddle', fromVercel(createReq('POST')));
 
     assert.equal(askriftPd.validRequest(), true);
     assert.equal(askriftPd.validPayload(), true);
@@ -322,20 +322,20 @@ describe('provider registry initialization', function () {
   });
 
   it('supports the existing boolean debug argument for paddle users', () => {
-    const askriftPd = initialize('paddle', reqFor('POST', JSON.stringify(validPayload), 'application/json'), true);
+    const askriftPd = initialize('paddle', fromVercel(createReq('POST')), true);
 
     assert.equal(askriftPd.validRequest(), true);
   });
 
   it('supports the options object debug argument for paddle users', () => {
-    const askriftPd = initialize('paddle', reqFor('POST', JSON.stringify(validPayload), 'application/json'), { debug: true });
+    const askriftPd = initialize('paddle', fromVercel(createReq('POST')), { debug: true });
 
     assert.equal(askriftPd.validRequest(), true);
   });
 
   it('throws UnsupportedProviderError for unsupported providers', () => {
     assert.throws(
-      () => initialize('stripe' as any, reqFor('POST', JSON.stringify(validPayload), 'application/json')),
+      () => initialize('stripe' as any, fromVercel(createReq('POST'))),
       UnsupportedProviderError,
       'Unsupported provider: stripe'
     );
@@ -343,7 +343,7 @@ describe('provider registry initialization', function () {
 
   it('throws UnsupportedProviderError for unsupported object prototype keys', () => {
     assert.throws(
-      () => initialize('__proto__' as any, reqFor('POST', JSON.stringify(validPayload), 'application/json')),
+      () => initialize('__proto__' as any, fromVercel(createReq('POST'))),
       UnsupportedProviderError,
       'Unsupported provider: __proto__'
     );

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -180,7 +180,7 @@ describe('library works with paddle', function () {
 
   it('should return consistent results when validPayload is called multiple times', () => {
     const req = reqFor('POST', { ...validPayload }, 'application/json');
-    const paddle = initialize('paddle', req);
+    const paddle = initialize('paddle', fromVercel(req));
 
     assert.equal(paddle.validPayload(), true);
     assert.equal(paddle.validPayload(), true);
@@ -189,7 +189,7 @@ describe('library works with paddle', function () {
   it('should not remove p_signature from object request bodies after verification', () => {
     const body = { ...validPayload };
     const originalBody = JSON.parse(JSON.stringify(body));
-    const paddle = initialize('paddle', reqFor('POST', body, 'application/json'));
+    const paddle = initialize('paddle', fromVercel(reqFor('POST', body, 'application/json')));
 
     assert.equal(paddle.validPayload(), true);
     assert.deepEqual(body, originalBody);
@@ -198,7 +198,7 @@ describe('library works with paddle', function () {
   it('should not replace string request bodies after verification', () => {
     const body = JSON.stringify(validPayload);
     const req = reqFor('POST', body, 'application/json');
-    const paddle = initialize('paddle', req);
+    const paddle = initialize('paddle', fromVercel(req));
 
     assert.equal(paddle.validPayload(), true);
     assert.equal(req.body, body);
@@ -214,7 +214,7 @@ describe('library works with paddle', function () {
 
   it('should reject payloads missing p_signature', () => {
     assert.equal(verifyPaddleSignature({ ...validPayloadWithoutSignature }, paddlePublicKey), false);
-    assert.equal(initialize('paddle', reqFor('POST', { ...validPayloadWithoutSignature }, 'application/json')).validPayload(), false);
+    assert.equal(initialize('paddle', fromVercel(reqFor('POST', { ...validPayloadWithoutSignature }, 'application/json'))).validPayload(), false);
   });
 
   it('should reject malformed signatures', () => {
@@ -224,14 +224,14 @@ describe('library works with paddle', function () {
     };
 
     assert.equal(verifyPaddleSignature(body, paddlePublicKey), false);
-    assert.equal(initialize('paddle', reqFor('POST', body, 'application/json')).validPayload(), false);
+    assert.equal(initialize('paddle', fromVercel(reqFor('POST', body, 'application/json'))).validPayload(), false);
   });
 
   it('should reject non-object payloads', () => {
     assert.equal(verifyPaddleSignature(null, paddlePublicKey), false);
     assert.equal(verifyPaddleSignature('not an object', paddlePublicKey), false);
-    assert.equal(initialize('paddle', reqFor('POST', JSON.stringify(null), 'application/json')).validPayload(), false);
-    assert.equal(initialize('paddle', reqFor('POST', JSON.stringify('not an object'), 'application/json')).validPayload(), false);
+    assert.equal(initialize('paddle', fromVercel(reqFor('POST', JSON.stringify(null), 'application/json'))).validPayload(), false);
+    assert.equal(initialize('paddle', fromVercel(reqFor('POST', JSON.stringify('not an object'), 'application/json'))).validPayload(), false);
   });
 
   it('should hand parsed body from validPayload to onSubscriptionCreated for string bodies', async () => {
@@ -241,7 +241,7 @@ describe('library works with paddle', function () {
     };
     const signedCreated = signPayload(createdPayload);
     const stringBody = JSON.stringify({ ...createdPayload, p_signature: signedCreated });
-    const paddle = initialize('paddle', reqFor('POST', stringBody, 'application/json'));
+    const paddle = initialize('paddle', fromVercel(reqFor('POST', stringBody, 'application/json')));
 
     assert.equal(paddle.validPayload(), true);
     const event = await paddle.onSubscriptionCreated();
@@ -252,14 +252,14 @@ describe('library works with paddle', function () {
 
   it('should accept requests whose content-type includes a charset parameter', () => {
     const formBody = new URLSearchParams(validPayload as any).toString();
-    const paddle = initialize('paddle', reqFor('POST', formBody, 'application/x-www-form-urlencoded; charset=utf-8'));
+    const paddle = initialize('paddle', fromVercel(reqFor('POST', formBody, 'application/x-www-form-urlencoded; charset=utf-8')));
 
     assert.equal(paddle.validRequest(), true);
   });
 
   it('should accept requests whose content-type is uppercase', () => {
     const formBody = new URLSearchParams(validPayload as any).toString();
-    const paddle = initialize('paddle', reqFor('POST', formBody, 'Application/X-WWW-Form-URLEncoded'));
+    const paddle = initialize('paddle', fromVercel(reqFor('POST', formBody, 'Application/X-WWW-Form-URLEncoded')));
 
     assert.equal(paddle.validRequest(), true);
   });
@@ -268,21 +268,21 @@ describe('library works with paddle', function () {
     const formBody = new URLSearchParams(validPayload as any).toString();
     const req = reqFor('POST', formBody, 'application/x-www-form-urlencoded');
     req.headers['content-type'] = ['application/x-www-form-urlencoded', 'text/plain'];
-    const paddle = initialize('paddle', req);
+    const paddle = initialize('paddle', fromVercel(req));
 
     assert.equal(paddle.validRequest(), true);
   });
 
   it('should reject requests whose content-type is not form-urlencoded or json', () => {
     const formBody = new URLSearchParams(validPayload as any).toString();
-    const paddle = initialize('paddle', reqFor('POST', formBody, 'text/plain'));
+    const paddle = initialize('paddle', fromVercel(reqFor('POST', formBody, 'text/plain')));
 
     assert.equal(paddle.validRequest(), false);
   });
 
   it('should verify signatures of form-urlencoded Paddle Classic webhooks', () => {
     const formBody = new URLSearchParams(validPayload as any).toString();
-    const paddle = initialize('paddle', reqFor('POST', formBody, 'application/x-www-form-urlencoded'));
+    const paddle = initialize('paddle', fromVercel(reqFor('POST', formBody, 'application/x-www-form-urlencoded')));
 
     assert.equal(paddle.validRequest(), true);
     assert.equal(paddle.validPayload(), true);
@@ -290,7 +290,7 @@ describe('library works with paddle', function () {
 
   it('should reject form-urlencoded bodies whose signature is invalid', () => {
     const invalidFormBody = new URLSearchParams(invalidPayload as any).toString();
-    const paddle = initialize('paddle', reqFor('POST', invalidFormBody, 'application/x-www-form-urlencoded'));
+    const paddle = initialize('paddle', fromVercel(reqFor('POST', invalidFormBody, 'application/x-www-form-urlencoded')));
 
     assert.equal(paddle.validRequest(), true);
     assert.equal(paddle.validPayload(), false);
@@ -298,7 +298,7 @@ describe('library works with paddle', function () {
 
   it('should make event handlers work after validRequest() without calling validPayload() first', async () => {
     const formBody = new URLSearchParams(validPayload as any).toString();
-    const paddle = initialize('paddle', reqFor('POST', formBody, 'application/x-www-form-urlencoded'));
+    const paddle = initialize('paddle', fromVercel(reqFor('POST', formBody, 'application/x-www-form-urlencoded')));
 
     assert.equal(paddle.validRequest(), true);
     const event = await paddle.onPaymentSucceeded();
@@ -352,7 +352,7 @@ describe('provider registry initialization', function () {
 
 describe('handle() propagates handler failures', function () {
   it('reports a thrown handler error and returns handled: false', async () => {
-    const askriftPd = initialize('paddle', createReq('POST'));
+    const askriftPd = initialize('paddle', fromVercel(createReq('POST')));
     const boom = new Error('handler exploded');
 
     askriftPd.on('subscription.payment.succeeded', () => {
@@ -370,7 +370,7 @@ describe('handle() propagates handler failures', function () {
   });
 
   it('reports an async rejection and returns handled: false', async () => {
-    const askriftPd = initialize('paddle', createReq('POST'));
+    const askriftPd = initialize('paddle', fromVercel(createReq('POST')));
 
     askriftPd.on('subscription.payment.succeeded', async () => {
       throw new Error('async boom');
@@ -386,7 +386,7 @@ describe('handle() propagates handler failures', function () {
   });
 
   it('returns handled: true and no errors when all handlers succeed', async () => {
-    const askriftPd = initialize('paddle', createReq('POST'));
+    const askriftPd = initialize('paddle', fromVercel(createReq('POST')));
     let called = 0;
 
     askriftPd.on('subscription.payment.succeeded', () => {

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -429,3 +429,35 @@ describe('paddle initialization options', function () {
     done();
   });
 });
+
+describe('request adapter falls back to rawBody', function () {
+  it('should use rawBody when body is undefined (string rawBody)', () => {
+    const rawBody = new URLSearchParams(validPayload).toString();
+    const paddle = initialize('paddle', fromVercel({
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      rawBody,
+    }));
+    assert.equal(paddle.validPayload(), true);
+  });
+
+  it('should use rawBody when body is undefined (Buffer rawBody)', () => {
+    const rawBody = Buffer.from(JSON.stringify(validPayload));
+    const paddle = initialize('paddle', fromVercel({
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      rawBody,
+    }));
+    assert.equal(paddle.validPayload(), true);
+  });
+
+  it('should prefer body over rawBody when body is defined', () => {
+    const paddle = initialize('paddle', fromVercel({
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: { ...validPayload },
+      rawBody: 'unused-raw-body',
+    }));
+    assert.equal(paddle.validPayload(), true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Reduce coupling between core provider logic and framework-specific request types by introducing a minimal internal request shape. 
- Provide small adapters so callers can convert Express/Vercel (or any) requests into the same canonical shape before initializing providers. 
- Keep provider logic framework-agnostic and simplify exports so adapters and types are available to consumers. 

### Description
- Added an `InternalRequest` type and `RequestHeaders` plus adapter helpers `fromRaw`, `fromExpress`, and `fromVercel` in `src/lib/request.ts` that normalize header names and preserve `body`/`rawBody`. 
- Updated public entry (`src/index.ts`) to export the adapters/types and changed `initialize()` to accept the `InternalRequest` shape. 
- Refactored Paddle provider (`src/lib/paddle.ts`) to accept the internal request, remove Express/Vercel imports, normalize header lookup via `firstHeaderValue`, and call `fromRaw` on construction. 
- Removed direct framework-type imports from `src/lib/askrift.ts`, removed unneeded framework dev/runtime deps from `package.json`, and documented adapter usage with examples in `README.md`. 

### Testing
- `npm run build` (TypeScript compile) completed successfully. 
- Ran a small adapter smoke check using the built `dist` to verify header normalization with `fromRaw`, which passed. 
- `npm run test` (mocha) failed due to the test environment not providing `PADDLE_PUBLIC_KEY` required by the Paddle provider, so existing webhook tests cannot complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28c14b4d8c83299295e763a4e6ff62)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ralphilius/askrift/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added framework-agnostic request adapters and a raw-request adapter for integrating Express, Vercel, and other frameworks.

* **Documentation**
  * Updated README examples to use the adapters and clarified webhook handler return structure, error capture, and adapter behavior (header normalization, body/rawBody handling).

* **Tests**
  * Updated tests to initialize webhooks via the new adapters and cover signature, content-type, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->