### PR TITLE
Add Stripe webhook support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,10 +105,6 @@ dist
 
 # Worktrees
 .worktrees/
-<<<<<<< HEAD
 
-# Worktrees
-.worktrees/
-=======
->>>>>>> 0ec8b40 (chore: ignore .worktrees directory)
-.worktrees/
+>>>>>>> 02652ed (chore: ignore .worktrees directory)
+---

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,3 @@ dist
 
 # Worktrees
 .worktrees/
-
->>>>>>> 02652ed (chore: ignore .worktrees directory)
----

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,10 @@ dist
 
 # Worktrees
 .worktrees/
+<<<<<<< HEAD
 
 # Worktrees
+.worktrees/
+=======
+>>>>>>> 0ec8b40 (chore: ignore .worktrees directory)
 .worktrees/

--- a/README.md
+++ b/README.md
@@ -1,132 +1,18 @@
-# Áskrift
+A small utilities library to make it easier to handle webhooks from popular subscription services
 
-A small TypeScript/JavaScript utilities library for validating and handling subscription webhooks from popular subscription services.
-
-**Áskrift** means “subscription” in Icelandic.
-
-## Installation
+**Áskrift** means subscription in Icelandic
 
 ```bash
-npm install @ralphilius/askrift
-# or
-# yarn add @ralphilius/askrift
-# or
-# pnpm add @ralphilius/askrift
+npm install @ralphilius/askrift # or yarn add @ralphilius/askrift
 ```
 
-## Use on your server
-
-Áskrift provider logic works with a small internal request shape instead of importing framework-specific request types:
-
-```ts
-type InternalRequest = {
-  method: string;
-  headers: Record<string, string | string[] | undefined>;
-  body: unknown;
-  rawBody?: Buffer | string;
-}
-```
-
-Use an adapter helper to convert the request from your framework before calling `initialize`.
-
-Áskrift can still be used with the provider-specific helpers (`validRequest()`,
-`validPayload()`, `onSubscriptionCreated()`, and friends), but new integrations
-can use the webhook dispatcher API:
-
-```ts
-askrift.on(eventName, handler);
-const result = await askrift.handle();
-```
-
-`handle()` validates the request, verifies the payload signature, parses the
-provider event, and invokes matching handlers. It returns a structured result:
-
-```ts
-{
-  verified: boolean;
-  handled: boolean;
-  eventType?: string;
-  errors?: Error[];
-}
-```
-
-`handled` is `true` only when at least one matching handler was invoked AND none
-of them threw. If any registered handler rejects, `handle()` catches the error,
-records it in `result.errors`, and returns `handled: false` so callers can map
-that to a 5xx response (instead of silently acknowledging a failed side effect).
-
-Event handlers receive the parsed payload and a context object that includes the
-normalized event name, the provider-specific event name, and the matched handler
-name. Paddle webhooks support normalized event names such as
-`subscription.created` and provider-specific names such as
-`paddle.subscription_payment_succeeded`.
-
-### Express example
-
-```ts
-import express from 'express';
-import { initialize, fromExpress } from '@ralphilius/askrift';
-
-const app = express();
-
-app.post('/webhooks/paddle', express.urlencoded({ extended: false }), async (req, res) => {
-  const askrift = initialize('paddle', fromExpress(req));
-
-  askrift.on('subscription.created', async (payload, event) => {
-    console.log('New subscription:', payload.subscription_id);
-    console.log('Provider event:', event.providerEventType);
-  });
-
-  askrift.on('paddle.subscription_payment_succeeded', async (payload) => {
-    console.log('Payment succeeded:', payload.subscription_payment_id);
-  });
-
-  const result = await askrift.handle();
-
-  if (!result.verified) return res.status(403).json(result);
-  if (!result.handled) return res.status(500).json(result);
-
-  return res.status(200).json(result);
-});
-```
-
-### Next.js API route example
-
-```ts
-import type { NextApiRequest, NextApiResponse } from 'next';
-import { initialize, fromVercel } from '@ralphilius/askrift';
-
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const askrift = initialize('paddle', fromVercel(req));
-
-  askrift.on('subscription.created', async (payload) => {
-    console.log('New subscription:', payload.subscription_id);
-  });
-
-  askrift.on('paddle.subscription_cancelled', async (payload) => {
-    console.log('Subscription cancelled:', payload.subscription_id);
-  });
-
-  const result = await askrift.handle();
-
-  if (!result.verified) return res.status(403).json(result);
-
-  return res.status(result.handled ? 200 : 202).json(result);
-}
-```
-
-### Explicit configuration
-Pass Paddle configuration directly to `initialize()` with an options object. `publicKey` can be either a full PEM public key or the body of the key without `-----BEGIN PUBLIC KEY-----` / `-----END PUBLIC KEY-----` headers.
-
+### Use on your server
+Example using Vercel/NextJS serverless function with Paddle:
 ```js
-import { initialize, fromVercel } from '@ralphilius/askrift'
+import { initialize } from '@ralphilius/askrift'
 
 module.exports = (req, res) => {
-  const askrift = initialize('paddle', fromVercel(req), {
-    publicKey: process.env.PADDLE_PUBLIC_KEY,
-    debug: process.env.NODE_ENV !== 'production',
-  });
-
+  const askrift = initialize("paddle", req);
   if(askrift.validRequest()){
     if(askrift.validPayload()){
       askrift.onSubscriptionCreated().then(subscription => {
@@ -141,573 +27,83 @@ module.exports = (req, res) => {
     res.status(400).end();
   }
 }
+
 ```
 
-### Environment variable fallback
-For backward compatibility, Áskrift will still read `process.env.PADDLE_PUBLIC_KEY` when you do not pass `publicKey` in the options object.
+### Stripe
+Set your Stripe webhook signing secret before initializing the handler:
 
-```js
-import { initialize, fromVercel } from '@ralphilius/askrift'
-
-module.exports = (req, res) => {
-  const askrift = initialize('paddle', fromVercel(req));
-
-  if(askrift.validRequest()){
-    if(askrift.validPayload()){
-      askrift.onSubscriptionCreated().then(subscription => {
-        // Handle subscription_created event
-      })
-    // Handle other events
-    } else {
-      // Invalid body, possibly leak of webhooks URL?
-      res.status(403).end();
-    }
-  } else {
-    res.status(400).end();
-  }
-}
+```bash
+STRIPE_WEBHOOK_SECRET=whsec_...
 ```
 
-### Raw/internal request objects
+Stripe validates signatures against the raw JSON payload. In frameworks that parse JSON before
+calling your handler, keep the raw body available as `req.rawBody` or pass the unmodified JSON
+string as `req.body`.
 
-If your framework is not covered by a dedicated helper, use `fromRaw` with the same minimal fields:
-
-```ts
-import { initialize, fromRaw } from '@ralphilius/askrift'
-
-const request = fromRaw({
-  method: 'POST',
-  headers: {
-    'content-type': 'application/x-www-form-urlencoded',
-  },
-  body: webhookBody,
-})
-
-const askrift = initialize('paddle', request)
-```
-
-The built-in adapters normalize header names to lowercase and pass through `body` and optional `rawBody` values.
-
-### Legacy provider-specific helper example
-
-```js
-import { initialize, fromVercel } from '@ralphilius/askrift';
-
-module.exports = (req, res) => {
-  const askrift = initialize('paddle', fromVercel(req));
-
-  if (askrift.validRequest()) {
-    if (askrift.validPayload()) {
-      askrift.onSubscriptionCreated().then(subscription => {
-        // Handle subscription_created event
-      });
-      // Handle other events
-    } else {
-      // Invalid body, possibly leak of webhooks URL?
-      res.status(403).end();
-    }
-  } else {
-    res.status(400).end();
-  }
-};
-```
-
-### Idempotency keys and replay windows
-
-Webhook providers often retry delivery, so your handler should accept the first delivery for a provider event and skip later deliveries with the same ID. Áskrift exposes the provider's stable event ID through a provider-neutral idempotency key:
+Example using a Vercel/NextJS serverless function:
 
 ```js
 import { initialize } from '@ralphilius/askrift'
 
-const askrift = initialize('paddle', req)
-
-if (!askrift.validRequest() || !askrift.validPayload({ maxAgeMs: 5 * 60 * 1000 })) {
-  res.status(400).end()
-  return
-}
-
-const idempotencyKey = askrift.getIdempotencyKey()
-// Paddle alert_id "120661188" becomes "paddle:120661188".
-```
-
-Normalized events returned from handlers expose the same `getIdempotencyKey()` method, plus timestamp helpers when a provider includes an event timestamp:
-
-```js
-const payment = await askrift.onPaymentSucceeded()
-
-if (payment) {
-  const idempotencyKey = payment.getIdempotencyKey()
-  const eventTimestamp = payment.getEventTimestamp()
-  const fresh = payment.isFresh({ maxAgeMs: 5 * 60 * 1000 })
-}
-```
-
-Use `getIdempotencyKey()` with any store that can atomically reserve a key before your business logic runs:
-
-```js
-const payment = await askrift.onPaymentSucceeded()
-if (!payment) return
-
-const key = payment.getIdempotencyKey()
-const ttlSeconds = 60 * 60 * 24 * 7
-
-// Database example: create a table with a UNIQUE constraint on `key`.
-try {
-  await db.webhookDeliveries.create({ data: { key } })
-} catch (error) {
-  // Duplicate key violation means this event was already handled.
-  return
-}
-
-// Redis example: SET key value NX EX ttlSeconds.
-const reserved = await redis.set(key, '1', { NX: true, EX: ttlSeconds })
-if (!reserved) return
-
-// KV example: use an atomic insert/create-if-not-exists operation.
-const created = await kv.set(key, '1', { ifNotExists: true, expirationTtl: ttlSeconds })
-if (!created) return
-
-// Safe to perform side effects after reserving the key.
-await provisionSubscription(payment)
-```
-
-You can also call the standalone helper if you are working with a raw provider payload:
-
-```js
-import { extractStableEventId } from '@ralphilius/askrift'
-
-const eventId = extractStableEventId('paddle', req.body)
-```
-
-## Supported services
-
-| Provider | Status | Signature verification | Supported events |
-| --- | --- | --- | --- |
-| Paddle | Supported | RSA/SHA1 verification with `p_signature` and `PADDLE_PUBLIC_KEY` | `subscription_created`, `subscription_updated`, `subscription_cancelled`, `subscription_payment_succeeded`, `subscription_payment_failed`, `subscription_payment_refunded` |
-| Stripe | Coming soon | Not implemented | Not implemented |
-| Gumroad | Coming soon | Not implemented | Not implemented |
-
-## Provider support matrix
-
-| Public method | Paddle event | Paddle support | Stripe support | Gumroad support |
-| --- | --- | --- | --- | --- |
-| `onSubscriptionCreated()` | `subscription_created` | ✅ | Planned | Planned |
-| `onSubscriptionUpdated()` | `subscription_updated` | ✅ | Planned | Planned |
-| `onSubscriptionCanceled()` | `subscription_cancelled` | ✅ | Planned | Planned |
-| `onPaymentSucceeded()` | `subscription_payment_succeeded` | ✅ | Planned | Planned |
-| `onPaymentFailed()` | `subscription_payment_failed` | ✅ | Planned | Planned |
-| `onPaymentRefunded()` | `subscription_payment_refunded` | ✅ | Planned | Planned |
-
-## Configuration
-
-### Paddle
-
-Áskrift currently requires Paddle’s public key at runtime.
-
-```bash
-PADDLE_PUBLIC_KEY="your-paddle-public-key-without-the-BEGIN-END-lines"
-```
-
-The library wraps the value with PEM headers internally, so store only the base64 key body. Both single-line keys and keys containing escaped newlines (`\n`) are supported.
-
-You can optionally enable debug logging by passing `true` as the third argument to `initialize()` or the second argument to `new Paddle()`:
-
-```ts
-import { initialize } from '@ralphilius/askrift';
-
-const askrift = initialize('paddle', req, true);
-```
-
-Do not enable debug logging in production unless you are comfortable with webhook payload data being written to your logs.
-
-## Request body requirements
-
-For Paddle webhooks, the request passed to Áskrift must include:
-
-- `method: 'POST'`.
-- A `content-type` header whose normalized value is `application/x-www-form-urlencoded`; parameters such as `charset=utf-8` are allowed.
-- A `body` containing Paddle’s webhook fields, including `p_signature` and `alert_name`.
-- A body representation that is either:
-  - a parsed object,
-  - a JSON string containing an object, or
-  - a URL-encoded string such as the raw `application/x-www-form-urlencoded` body.
-
-Recommended request handling order:
-
-1. Construct the provider with the request: `const askrift = initialize('paddle', req)`.
-2. Reject requests that fail `askrift.validRequest()`.
-3. Reject requests that fail `askrift.validPayload()`.
-4. Call the event method that matches the event you want to handle.
-
-```ts
-const askrift = initialize('paddle', req);
-
-if (!askrift.validRequest()) {
-  // Wrong HTTP method or content type.
-  return;
-}
-
-if (!askrift.validPayload()) {
-  // Invalid or missing Paddle signature.
-  return;
-}
-
-const subscription = await askrift.onSubscriptionCreated();
-if (subscription) {
-  // Handle subscription_created.
-}
-```
-
-## Provider setup
-
-### Paddle dashboard
-
-1. Add a webhook endpoint in Paddle that points to your server route.
-2. Select the subscription events you want to receive.
-3. Copy your Paddle public key from Paddle’s developer/webhook settings.
-4. Store the public key in `PADDLE_PUBLIC_KEY` without the `-----BEGIN PUBLIC KEY-----` and `-----END PUBLIC KEY-----` lines.
-5. Ensure your route accepts `POST` requests with `application/x-www-form-urlencoded` bodies.
-
-### Future providers
-
-Stripe and Gumroad are listed as future providers. Until they are implemented, `initialize('stripe', req)` and `initialize('gumroad', req)` are not supported. Future provider classes should expose the same public contract as `Askrift`: request validation, payload validation, debug logging, and event helpers that resolve either a provider-specific payload or `null` when the current event does not match the method.
-
-## Usage examples
-
-### Express
-
-Paddle sends form-encoded webhook data. Use `express.urlencoded()` for the webhook route, and keep JSON parsing from changing the request before validation.
-
-```ts
-import express from 'express';
-import { initialize } from '@ralphilius/askrift';
-
-const app = express();
-
-app.post('/webhooks/paddle', express.urlencoded({ extended: false }), async (req, res) => {
-  const askrift = initialize('paddle', req);
+module.exports = async (req, res) => {
+  const askrift = initialize("stripe", req);
 
   if (!askrift.validRequest()) {
-    return res.status(400).send('Invalid webhook request');
+    res.status(400).end();
+    return;
   }
 
   if (!askrift.validPayload()) {
-    return res.status(403).send('Invalid webhook signature');
+    res.status(403).end();
+    return;
   }
 
   const created = await askrift.onSubscriptionCreated();
   if (created) {
-    // Handle Paddle subscription_created.
-    return res.status(200).send('ok');
+    // Handle customer.subscription.created
   }
 
   const updated = await askrift.onSubscriptionUpdated();
   if (updated) {
-    // Handle Paddle subscription_updated.
-    return res.status(200).send('ok');
+    // Handle customer.subscription.updated
   }
 
   const canceled = await askrift.onSubscriptionCanceled();
   if (canceled) {
-    // Handle Paddle subscription_cancelled.
-    return res.status(200).send('ok');
+    // Handle customer.subscription.deleted
   }
 
   const paymentSucceeded = await askrift.onPaymentSucceeded();
   if (paymentSucceeded) {
-    // Handle Paddle subscription_payment_succeeded.
-    return res.status(200).send('ok');
+    // Handle invoice.payment_succeeded
   }
 
   const paymentFailed = await askrift.onPaymentFailed();
   if (paymentFailed) {
-    // Handle Paddle subscription_payment_failed.
-    return res.status(200).send('ok');
+    // Handle invoice.payment_failed
   }
 
-  const paymentRefunded = await askrift.onPaymentRefunded();
-  if (paymentRefunded) {
-    // Handle Paddle subscription_payment_refunded.
-    return res.status(200).send('ok');
-  }
-
-  return res.status(200).send('ignored');
-});
-```
-
-### Next.js route handler (`app/api/.../route.ts`)
-
-Next.js route handlers expose a Web `Request`, while Áskrift expects an Express/Vercel-like object containing `method`, `headers`, and `body`. Convert the form body into a plain object before calling `initialize()`.
-
-```ts
-import { initialize } from '@ralphilius/askrift';
-
-export async function POST(request: Request) {
-  const contentType = request.headers.get('content-type')?.split(';')[0].trim().toLowerCase();
-
-  if (contentType !== 'application/x-www-form-urlencoded') {
-    return new Response('Unsupported Media Type', { status: 415 });
-  }
-
-  let body: Record<string, string>;
-  try {
-    const formData = await request.formData();
-    body = Object.fromEntries(formData.entries()) as Record<string, string>;
-  } catch {
-    return new Response('Invalid webhook payload', { status: 400 });
-  }
-
-  const req = {
-    method: 'POST',
-    headers: {
-      'content-type': contentType,
-    },
-    body,
-  };
-
-  const askrift = initialize('paddle', req as any);
-
-  if (!askrift.validRequest()) {
-    return new Response('Invalid webhook request', { status: 400 });
-  }
-
-  if (!askrift.validPayload()) {
-    return new Response('Invalid webhook signature', { status: 403 });
-  }
-
-  const paymentSucceeded = await askrift.onPaymentSucceeded();
-  if (paymentSucceeded) {
-    // Fulfill the order or extend access.
-  }
-
-  return new Response('ok', { status: 200 });
+  res.status(200).end();
 }
 ```
 
-### Next.js Pages API route (`pages/api/...`) with Vercel-compatible requests
+You can also access Stripe-specific helpers by importing `Stripe` and casting the initialized
+handler when you need a normalized event payload:
 
-If you use a Pages API route, disable the built-in body parser and parse the raw form-encoded body yourself so the request shape stays predictable.
+```js
+import { initialize, Stripe } from '@ralphilius/askrift'
 
-```ts
-import type { NextApiRequest, NextApiResponse } from 'next';
-import { initialize } from '@ralphilius/askrift';
-
-export const config = {
-  api: {
-    bodyParser: false,
-  },
-};
-
-async function readBody(req: NextApiRequest): Promise<string> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req) {
-    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
-  }
-  return Buffer.concat(chunks).toString('utf8');
-}
-
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  req.body = await readBody(req);
-
-  const askrift = initialize('paddle', req);
-
-  if (!askrift.validRequest()) {
-    return res.status(400).send('Invalid webhook request');
-  }
-
-  if (!askrift.validPayload()) {
-    return res.status(403).send('Invalid webhook signature');
-  }
-
-  const canceled = await askrift.onSubscriptionCanceled();
-  if (canceled) {
-    // Revoke access or schedule cancellation handling.
-  }
-
-  return res.status(200).send('ok');
+const askrift = initialize("stripe", req);
+if (askrift.validPayload()) {
+  const normalized = /** @type {Stripe} */ (askrift).getNormalizedEvent();
+  // normalized.type is one of:
+  // subscription.created, subscription.updated, subscription.deleted,
+  // payment.succeeded, payment.failed
 }
 ```
 
-### Vercel serverless function
-
-```ts
-import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { initialize } from '@ralphilius/askrift';
-
-export default async function handler(req: VercelRequest, res: VercelResponse) {
-  const askrift = initialize('paddle', req);
-
-  if (!askrift.validRequest()) {
-    return res.status(400).send('Invalid webhook request');
-  }
-
-  if (!askrift.validPayload()) {
-    return res.status(403).send('Invalid webhook signature');
-  }
-
-  const created = await askrift.onSubscriptionCreated();
-  const paymentSucceeded = await askrift.onPaymentSucceeded();
-
-  if (created) {
-    // Provision the subscription.
-  } else if (paymentSucceeded) {
-    // Record a successful renewal/payment.
-  }
-
-  return res.status(200).send('ok');
-}
-```
-
-### Framework-agnostic raw request
-
-Use this pattern when your framework gives you raw HTTP request data or when you want to adapt another runtime to Áskrift’s expected request shape.
-
-```ts
-import { initialize } from '@ralphilius/askrift';
-
-type RawWebhookRequest = {
-  method: string;
-  headers: Record<string, string | string[] | undefined>;
-  rawBody: string;
-};
-
-export async function handlePaddleWebhook(rawReq: RawWebhookRequest) {
-  const req = {
-    method: rawReq.method,
-    headers: rawReq.headers,
-    body: rawReq.rawBody,
-  };
-
-  const askrift = initialize('paddle', req as any);
-
-  if (!askrift.validRequest()) {
-    return { status: 400, body: 'Invalid webhook request' };
-  }
-
-  if (!askrift.validPayload()) {
-    return { status: 403, body: 'Invalid webhook signature' };
-  }
-
-  const event =
-    (await askrift.onSubscriptionCreated()) ||
-    (await askrift.onSubscriptionUpdated()) ||
-    (await askrift.onSubscriptionCanceled()) ||
-    (await askrift.onPaymentSucceeded()) ||
-    (await askrift.onPaymentFailed()) ||
-    (await askrift.onPaymentRefunded());
-
-  if (!event) {
-    return { status: 200, body: 'ignored' };
-  }
-
-  // Dispatch by event.alert_name or pass the payload to your job queue.
-  return { status: 200, body: 'ok' };
-}
-```
-
-## Public API
-
-### `initialize(type, body, debug?)`
-
-Creates a provider instance.
-
-| Argument | Type | Description |
-| --- | --- | --- |
-| `type` | `'paddle'` | Provider key. Only `'paddle'` is currently implemented. |
-| `body` | `VercelRequest \| Express.Request` | Request-like object containing `method`, `headers`, and `body`. |
-| `debug` | `boolean` | Optional. Enables provider debug logging when `true`. |
-
-Returns an `Askrift<'paddle'>` instance backed by the Paddle provider.
-
-### `Askrift<Provider>`
-
-`Askrift` is the abstract base class and public contract implemented by each provider.
-
-| Method | Returns | Description |
-| --- | --- | --- |
-| `validRequest()` | `boolean` | Checks request-level requirements such as HTTP method and content type. For Paddle, this requires `POST` and `application/x-www-form-urlencoded`. |
-| `validPayload()` | `boolean` | Verifies provider-specific payload authenticity. For Paddle, this validates the `p_signature` field against `PADDLE_PUBLIC_KEY`. |
-| `debug(msg, ...optionalParams)` | `void` | Writes to `console.log` only when debug mode is enabled. |
-| `onSubscriptionCreated()` | `Promise<Payload \| null>` | Resolves the provider-specific subscription-created payload when the current event matches; otherwise resolves `null`. |
-| `onSubscriptionUpdated()` | `Promise<Payload \| null>` | Resolves the provider-specific subscription-updated payload when the current event matches; otherwise resolves `null`. |
-| `onSubscriptionCanceled()` | `Promise<Payload \| null>` | Resolves the provider-specific subscription-canceled payload when the current event matches; otherwise resolves `null`. |
-| `onPaymentSucceeded()` | `Promise<Payload \| null>` | Resolves the provider-specific payment-succeeded payload when the current event matches; otherwise resolves `null`. |
-| `onPaymentFailed()` | `Promise<Payload \| null>` | Resolves the provider-specific payment-failed payload when the current event matches; otherwise resolves `null`. |
-| `onPaymentRefunded()` | `Promise<Payload \| null>` | Resolves the provider-specific payment-refunded payload when the current event matches; otherwise resolves `null`. |
-
-### `Paddle`
-
-`Paddle` implements `Askrift<'paddle'>`.
-
-```ts
-import Paddle from '@ralphilius/askrift/dist/lib/paddle';
-
-const paddle = new Paddle(req, false);
-```
-
-Most consumers should prefer `initialize('paddle', req)` instead of importing the class directly.
-
-| Constructor/method | Description |
-| --- | --- |
-| `new Paddle(req, debugged?)` | Creates a Paddle provider for a Vercel or Express request. Throws if `PADDLE_PUBLIC_KEY` is missing. |
-| `validRequest()` | Returns `true` only for `POST` requests with `application/x-www-form-urlencoded` content type. |
-| `validPayload()` | Parses the request body, removes `p_signature` from the signed payload copy, sorts the remaining fields, PHP-serializes them, and verifies the RSA/SHA1 signature. Returns `false` for missing, malformed, or invalid signatures. |
-| `debug(msg, ...optionalParams)` | Logs debug output only when the provider was created with debug mode enabled. |
-| `onSubscriptionCreated()` | Resolves a `SubscriptionCreated` payload when `alert_name === 'subscription_created'`; otherwise resolves `null`. |
-| `onSubscriptionUpdated()` | Resolves a `SubscriptionUpdated` payload when `alert_name === 'subscription_updated'`; otherwise resolves `null`. |
-| `onSubscriptionCanceled()` | Resolves a `SubscriptionCancelled` payload when `alert_name === 'subscription_cancelled'`; otherwise resolves `null`. |
-| `onPaymentSucceeded()` | Resolves a `SubscriptionPaymentSucceeded` payload when `alert_name === 'subscription_payment_succeeded'`; otherwise resolves `null`. |
-| `onPaymentFailed()` | Resolves a `SubscriptionPaymentFailed` payload when `alert_name === 'subscription_payment_failed'`; otherwise resolves `null`. |
-| `onPaymentRefunded()` | Resolves a `SubscriptionPaymentRefunded` payload when `alert_name === 'subscription_payment_refunded'`; otherwise resolves `null`. |
-
-### Future provider classes
-
-Future providers should implement the complete `Askrift` public method set. Provider-specific event names may differ, but the public methods should keep the same meaning so application code can switch providers with minimal branching. A future provider should document:
-
-- required environment variables or secrets,
-- accepted request methods and content types,
-- signature or authenticity checks performed by `validPayload()`,
-- event names mapped to each `on...()` method,
-- exact payload type returned by every event helper.
-
-## Security notes
-
-- Always call `validRequest()` and `validPayload()` before trusting webhook data or performing side effects.
-- Keep `PADDLE_PUBLIC_KEY` in server-side environment variables only. Do not expose it to browser bundles or client-side logs.
-- Return a non-2xx response for invalid signatures so webhook senders can surface delivery failures during setup.
-- Treat webhook URLs as secrets. If a URL leaks, rotate it in your provider dashboard and deploy the new route.
-- Make handlers idempotent. Providers may retry events, and duplicate webhook deliveries should not duplicate billing or provisioning side effects.
-- Avoid logging full payloads in production because webhook bodies may contain emails, customer names, order IDs, and subscription identifiers.
-- Restrict webhook routes to expected HTTP methods and content types. Áskrift checks this for Paddle, but infrastructure-level restrictions are still useful.
-
-## Troubleshooting
-
-### `validPayload()` returns `false` for an invalid signature
-
-- Confirm that `PADDLE_PUBLIC_KEY` is the Paddle public key body without PEM header/footer lines.
-- Confirm that the payload includes `p_signature` exactly as Paddle sent it.
-- Do not modify, rename, or drop fields before validation.
-- Ensure your endpoint is receiving the Paddle event you configured in the Paddle dashboard.
-
-### `validRequest()` returns `false` for the wrong content type
-
-- Paddle requests must use `application/x-www-form-urlencoded`.
-- Content-type parameters are allowed, for example `application/x-www-form-urlencoded; charset=utf-8`.
-- If your framework reports `application/json`, fix the webhook route or body parser configuration before calling Áskrift.
-
-### `PADDLE_PUBLIC_KEY is required`
-
-- Set `PADDLE_PUBLIC_KEY` in the server environment that runs the webhook handler.
-- Restart or redeploy the application after adding the variable.
-- Store the key without the PEM header and footer lines; Áskrift adds them internally.
-
-### Body parser issues
-
-- If `req.body` is `undefined`, add a route-level parser such as `express.urlencoded({ extended: false })` or read the raw body manually.
-- If signature validation fails after parsing, confirm the parser preserves every field, including `p_signature`.
-- For Next.js Pages API routes, disable the built-in body parser when you need raw request access.
-- For Next.js route handlers, use `await request.formData()` and convert the result with `Object.fromEntries()`.
-
-## License
-
-MIT
+### Supported Services
+ - Paddle
+ - Stripe
+ - Gumroad (Coming soon)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,876 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      crypto:
+        specifier: ^1.0.1
+        version: 1.0.1
+      php-serialize:
+        specifier: ^4.0.2
+        version: 4.1.1
+    devDependencies:
+      '@types/chai':
+        specifier: ^4.2.21
+        version: 4.3.20
+      '@types/mocha':
+        specifier: ^9.0.0
+        version: 9.1.1
+      '@types/node':
+        specifier: ^16.9.1
+        version: 16.18.126
+      chai:
+        specifier: ^4.3.4
+        version: 4.5.0
+      dotenv:
+        specifier: ^10.0.0
+        version: 10.0.0
+      mocha:
+        specifier: ^9.1.1
+        version: 9.2.2
+      ts-node:
+        specifier: ^10.2.1
+        version: 10.9.2(@types/node@16.18.126)(typescript@4.9.5)
+      typescript:
+        specifier: ^4.4.3
+        version: 4.9.5
+
+packages:
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@tsconfig/node10@1.0.12':
+    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/chai@4.3.20':
+    resolution: {integrity: sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==}
+
+  '@types/mocha@9.1.1':
+    resolution: {integrity: sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==}
+
+  '@types/node@16.18.126':
+    resolution: {integrity: sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==}
+
+  '@ungap/promise-all-settled@1.1.2':
+    resolution: {integrity: sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ansi-colors@4.1.1:
+    resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==}
+    engines: {node: '>=6'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browser-stdout@1.3.1:
+    resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  chokidar@3.5.3:
+    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  crypto@1.0.1:
+    resolution: {integrity: sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==}
+    deprecated: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.
+
+  debug@4.3.3:
+    resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decamelize@4.0.0:
+    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
+    engines: {node: '>=10'}
+
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
+    engines: {node: '>=0.3.1'}
+
+  diff@5.0.0:
+    resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
+    engines: {node: '>=0.3.1'}
+
+  dotenv@10.0.0:
+    resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
+    engines: {node: '>=10'}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat@5.0.2:
+    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
+    hasBin: true
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob@7.2.0:
+    resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  growl@1.10.5:
+    resolution: {integrity: sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==}
+    engines: {node: '>=4.x'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@4.2.1:
+    resolution: {integrity: sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==}
+    engines: {node: '>=10'}
+
+  mocha@9.2.2:
+    resolution: {integrity: sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==}
+    engines: {node: '>= 12.0.0'}
+    hasBin: true
+
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.1:
+    resolution: {integrity: sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
+  php-serialize@4.1.1:
+    resolution: {integrity: sha512-7drCrSZdJ05UdG3hyYEIRW0XyKyUFkxa5A3dpIp3NTjUHpI080pkdBAvqaBtkA+kBkMeXX3XnaSnaLGJRz071A==}
+    engines: {node: '>= 8'}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  serialize-javascript@6.0.0:
+    resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
+  typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  workerpool@6.2.0:
+    resolution: {integrity: sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@20.2.4:
+    resolution: {integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==}
+    engines: {node: '>=10'}
+
+  yargs-unparser@2.0.0:
+    resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@tsconfig/node10@1.0.12': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
+  '@types/chai@4.3.20': {}
+
+  '@types/mocha@9.1.1': {}
+
+  '@types/node@16.18.126': {}
+
+  '@ungap/promise-all-settled@1.1.2': {}
+
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  ansi-colors@4.1.1: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  arg@4.1.3: {}
+
+  argparse@2.0.1: {}
+
+  assertion-error@1.1.0: {}
+
+  balanced-match@1.0.2: {}
+
+  binary-extensions@2.3.0: {}
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browser-stdout@1.3.1: {}
+
+  camelcase@6.3.0: {}
+
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
+
+  chokidar@3.5.3:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  create-require@1.1.1: {}
+
+  crypto@1.0.1: {}
+
+  debug@4.3.3(supports-color@8.1.1):
+    dependencies:
+      ms: 2.1.2
+    optionalDependencies:
+      supports-color: 8.1.1
+
+  decamelize@4.0.0: {}
+
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
+  diff@4.0.4: {}
+
+  diff@5.0.0: {}
+
+  dotenv@10.0.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat@5.0.2: {}
+
+  fs.realpath@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-caller-file@2.0.5: {}
+
+  get-func-name@2.0.2: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@7.2.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  growl@1.10.5: {}
+
+  has-flag@4.0.0: {}
+
+  he@1.2.0: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  is-plain-obj@2.1.0: {}
+
+  is-unicode-supported@0.1.0: {}
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
+  make-error@1.3.6: {}
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
+  minimatch@4.2.1:
+    dependencies:
+      brace-expansion: 1.1.15
+
+  mocha@9.2.2:
+    dependencies:
+      '@ungap/promise-all-settled': 1.1.2
+      ansi-colors: 4.1.1
+      browser-stdout: 1.3.1
+      chokidar: 3.5.3
+      debug: 4.3.3(supports-color@8.1.1)
+      diff: 5.0.0
+      escape-string-regexp: 4.0.0
+      find-up: 5.0.0
+      glob: 7.2.0
+      growl: 1.10.5
+      he: 1.2.0
+      js-yaml: 4.1.0
+      log-symbols: 4.1.0
+      minimatch: 4.2.1
+      ms: 2.1.3
+      nanoid: 3.3.1
+      serialize-javascript: 6.0.0
+      strip-json-comments: 3.1.1
+      supports-color: 8.1.1
+      which: 2.0.2
+      workerpool: 6.2.0
+      yargs: 16.2.0
+      yargs-parser: 20.2.4
+      yargs-unparser: 2.0.0
+
+  ms@2.1.2: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.1: {}
+
+  normalize-path@3.0.0: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
+
+  pathval@1.1.1: {}
+
+  php-serialize@4.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
+  require-directory@2.1.1: {}
+
+  safe-buffer@5.2.1: {}
+
+  serialize-javascript@6.0.0:
+    dependencies:
+      randombytes: 2.1.0
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  ts-node@10.9.2(@types/node@16.18.126)(typescript@4.9.5):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 16.18.126
+      acorn: 8.17.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 4.9.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  type-detect@4.1.0: {}
+
+  typescript@4.9.5: {}
+
+  v8-compile-cache-lib@3.0.1: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  workerpool@6.2.0: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@20.2.4: {}
+
+  yargs-unparser@2.0.0:
+    dependencies:
+      camelcase: 6.3.0
+      decamelize: 4.0.0
+      flat: 5.0.2
+      is-plain-obj: 2.1.0
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.4
+
+  yn@3.1.1: {}
+
+  yocto-queue@0.1.0: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,22 @@
 import Askrift, { AskriftEventContext, AskriftEventHandler, AskriftHandleResult, AskriftParsedEvent } from "./lib/askrift";
 import Paddle, { PaddleOptions, PaddleProviderKind } from "./lib/paddle";
+import Stripe from "./lib/stripe";
 import { fromExpress, fromRaw, fromVercel } from "./lib/request";
 import type { InternalRequest, RequestHeaders } from "./lib/request";
 
 export default Askrift;
-export { Paddle };
+export { Paddle, Stripe };
 export { verifyPaddleSignature } from "./lib/paddle";
 export { fromExpress, fromRaw, fromVercel };
 export { AskriftEventContext, AskriftEventHandler, AskriftHandleResult, AskriftParsedEvent };
 export * from "./types/events";
+export * from "./types/stripe";
 export type { InternalRequest, RequestHeaders } from "./lib/request";
 export type { PaddleOptions, PaddleProviderKind, PaddleSubscriptionEvents } from "./lib/paddle";
 
 export type TypesMap = {
   paddle: Paddle;
+  stripe: Stripe;
   'paddle-classic': Paddle;
   'paddle-billing': Paddle;
 };
@@ -27,6 +30,7 @@ const providers: { [T in keyof TypesMap]: ProviderConstructor<T> } = {
   paddle: Paddle,
   'paddle-classic': Paddle,
   'paddle-billing': Paddle,
+  stripe: Stripe,
 };
 
 export class UnsupportedProviderError extends Error {

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,9 @@ export function initialize(type: string, request: ProviderRequest, options?: Ini
 
   const Provider = providers[type as keyof TypesMap];
   const baseOptions = resolveOptions(options);
+  const debugOption = typeof baseOptions === 'boolean' ? { debug: baseOptions } : {};
   const mergedOptions: PaddleOptions & Partial<StripeOptions> = {
+    ...debugOption,
     ...(typeof baseOptions === 'object' && baseOptions !== null ? baseOptions : {}),
     ...(type === 'stripe' ? {} : { kind: type as PaddleProviderKind }),
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import Askrift, { AskriftEventContext, AskriftEventHandler, AskriftHandleResult, AskriftParsedEvent } from "./lib/askrift";
 import Paddle, { PaddleOptions, PaddleProviderKind } from "./lib/paddle";
-import Stripe from "./lib/stripe";
+import Stripe, { StripeOptions } from "./lib/stripe";
 import { fromExpress, fromRaw, fromVercel } from "./lib/request";
 import type { InternalRequest, RequestHeaders } from "./lib/request";
 
@@ -13,6 +13,7 @@ export * from "./types/events";
 export * from "./types/stripe";
 export type { InternalRequest, RequestHeaders } from "./lib/request";
 export type { PaddleOptions, PaddleProviderKind, PaddleSubscriptionEvents } from "./lib/paddle";
+export type { StripeOptions } from "./lib/stripe";
 
 export type TypesMap = {
   paddle: Paddle;
@@ -21,10 +22,10 @@ export type TypesMap = {
   'paddle-billing': Paddle;
 };
 
-export type InitializeOptions = PaddleOptions;
+export type InitializeOptions = PaddleOptions & Partial<StripeOptions>;
 
 type ProviderRequest = InternalRequest;
-type ProviderConstructor<T extends keyof TypesMap> = new (request: InternalRequest, options?: PaddleOptions | boolean) => TypesMap[T];
+type ProviderConstructor<T extends keyof TypesMap> = new (request: InternalRequest, options?: PaddleOptions & Partial<StripeOptions> | boolean) => TypesMap[T];
 
 const providers: { [T in keyof TypesMap]: ProviderConstructor<T> } = {
   paddle: Paddle,
@@ -41,7 +42,7 @@ export class UnsupportedProviderError extends Error {
   }
 }
 
-function resolveOptions(options?: InitializeOptions | boolean): PaddleOptions | boolean | undefined {
+function resolveOptions(options?: InitializeOptions | boolean): (PaddleOptions & Partial<StripeOptions>) | boolean | undefined {
   if (typeof options === 'boolean') return options;
   return options;
 }
@@ -54,9 +55,9 @@ export function initialize(type: string, request: ProviderRequest, options?: Ini
 
   const Provider = providers[type as keyof TypesMap];
   const baseOptions = resolveOptions(options);
-  const mergedOptions: PaddleOptions = {
+  const mergedOptions: PaddleOptions & Partial<StripeOptions> = {
     ...(typeof baseOptions === 'object' && baseOptions !== null ? baseOptions : {}),
-    kind: type as PaddleProviderKind,
+    ...(type === 'stripe' ? {} : { kind: type as PaddleProviderKind }),
   };
   return new Provider(request, mergedOptions);
 };

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -1,6 +1,6 @@
 import { isObject } from "./utils";
 
-export type WebhookProvider = 'paddle';
+export type WebhookProvider = 'paddle' | 'stripe' | 'gumroad' | 'lemon-squeezy' | 'polar';
 
 export type EventTimestampValidationOptions = {
   /** Maximum accepted event age in milliseconds. */
@@ -25,12 +25,29 @@ export interface NormalizedWebhookEvent {
 type ProviderConfig = {
   idFields: string[];
   timestampFields: string[];
+  parseTimestamp?: (value: unknown) => Date | null;
 };
 
 const PROVIDER_CONFIG: Record<WebhookProvider, ProviderConfig> = {
   paddle: {
     idFields: ['alert_id'],
     timestampFields: ['event_time'],
+  },
+  stripe: {
+    idFields: ['id'],
+    timestampFields: ['created'],
+  },
+  gumroad: {
+    idFields: ['id'],
+    timestampFields: ['created_at'],
+  },
+  'lemon-squeezy': {
+    idFields: ['meta', 'event_id'],
+    timestampFields: ['meta', 'created_at'],
+  },
+  polar: {
+    idFields: ['id'],
+    timestampFields: ['timestamp'],
   },
 };
 
@@ -75,7 +92,13 @@ export function extractEventTimestamp(provider: WebhookProvider, payload: unknow
 
   for (const field of PROVIDER_CONFIG[provider].timestampFields) {
     const value = parsedPayload[field];
-    const timestamp = provider === 'paddle' ? parsePaddleTimestamp(value) : null;
+    let timestamp: Date | null = null;
+    if (provider === 'paddle') {
+      timestamp = parsePaddleTimestamp(value);
+    } else if (typeof value === 'string' || typeof value === 'number') {
+      const date = new Date(value);
+      timestamp = Number.isNaN(date.getTime()) ? null : date;
+    }
     if (timestamp) return timestamp;
   }
 

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -32,10 +32,12 @@ const PROVIDER_CONFIG: Record<WebhookProvider, ProviderConfig> = {
   paddle: {
     idFields: ['alert_id'],
     timestampFields: ['event_time'],
+    parseTimestamp: parsePaddleTimestamp,
   },
   stripe: {
     idFields: ['id'],
     timestampFields: ['created'],
+    parseTimestamp: parseUnixSecondsTimestamp,
   },
   gumroad: {
     idFields: ['id'],
@@ -67,6 +69,22 @@ function parsePaddleTimestamp(value: unknown): Date | null {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
+function parseUnixSecondsTimestamp(value: unknown): Date | null {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const date = new Date(value * 1000);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+      const date = new Date(numeric * 1000);
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+  }
+  return null;
+}
+
 function coerceNow(now: Date | number | undefined): number {
   if (now instanceof Date) return now.getTime();
   if (typeof now === 'number') return now;
@@ -92,9 +110,10 @@ export function extractEventTimestamp(provider: WebhookProvider, payload: unknow
 
   for (const field of PROVIDER_CONFIG[provider].timestampFields) {
     const value = parsedPayload[field];
+    const customParser = PROVIDER_CONFIG[provider].parseTimestamp;
     let timestamp: Date | null = null;
-    if (provider === 'paddle') {
-      timestamp = parsePaddleTimestamp(value);
+    if (customParser) {
+      timestamp = customParser(value);
     } else if (typeof value === 'string' || typeof value === 'number') {
       const date = new Date(value);
       timestamp = Number.isNaN(date.getTime()) ? null : date;

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -57,6 +57,17 @@ function asPayload(payload: unknown): Record<string, any> | null {
   return isObject(payload) && !Array.isArray(payload) ? payload as Record<string, any> : null;
 }
 
+function resolvePath(target: unknown, path: string | string[]): unknown {
+  const segments = Array.isArray(path) ? path : [path];
+  let current: unknown = target;
+  for (const segment of segments) {
+    if (current === undefined || current === null) return undefined;
+    if (typeof current !== 'object') return undefined;
+    current = (current as Record<string, any>)[segment];
+  }
+  return current;
+}
+
 function parsePaddleTimestamp(value: unknown): Date | null {
   if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
   if (typeof value !== 'string' || value.trim() === '') return null;
@@ -96,7 +107,7 @@ export function extractStableEventId(provider: WebhookProvider, payload: unknown
   if (!parsedPayload) return null;
 
   for (const field of PROVIDER_CONFIG[provider].idFields) {
-    const value = parsedPayload[field];
+    const value = resolvePath(parsedPayload, field);
     if (typeof value === 'string' && value.trim() !== '') return value.trim();
     if (typeof value === 'number' && Number.isFinite(value)) return String(value);
   }
@@ -109,7 +120,7 @@ export function extractEventTimestamp(provider: WebhookProvider, payload: unknow
   if (!parsedPayload) return null;
 
   for (const field of PROVIDER_CONFIG[provider].timestampFields) {
-    const value = parsedPayload[field];
+    const value = resolvePath(parsedPayload, field);
     const customParser = PROVIDER_CONFIG[provider].parseTimestamp;
     let timestamp: Date | null = null;
     if (customParser) {

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,223 @@
+import { VercelRequest } from "@vercel/node";
+import { Request } from "express";
+import * as crypto from "crypto";
+import Askrift from "./askrift";
+import {
+  NormalizedStripeEvent,
+  StripeCustomerSubscriptionCreatedEvent,
+  StripeCustomerSubscriptionDeletedEvent,
+  StripeCustomerSubscriptionUpdatedEvent,
+  StripeEvent,
+  StripeInvoice,
+  StripeInvoicePaymentFailedEvent,
+  StripeInvoicePaymentSucceededEvent,
+  StripeSubscription,
+  StripeSupportedEvent,
+  StripeSupportedEventType,
+} from "../types/stripe";
+
+const SUPPORTED_EVENTS: StripeSupportedEventType[] = [
+  "customer.subscription.created",
+  "customer.subscription.updated",
+  "customer.subscription.deleted",
+  "invoice.payment_succeeded",
+  "invoice.payment_failed",
+];
+
+const NORMALIZED_TYPES: Record<StripeSupportedEventType, NormalizedStripeEvent["type"]> = {
+  "customer.subscription.created": "subscription.created",
+  "customer.subscription.updated": "subscription.updated",
+  "customer.subscription.deleted": "subscription.deleted",
+  "invoice.payment_succeeded": "payment.succeeded",
+  "invoice.payment_failed": "payment.failed",
+};
+
+type StripeRequest = VercelRequest | Request;
+
+function isStripeSupportedEventType(type: string): type is StripeSupportedEventType {
+  return SUPPORTED_EVENTS.indexOf(type as StripeSupportedEventType) >= 0;
+}
+
+function timingSafeEqual(expected: string, actual: string): boolean {
+  const expectedBuffer = Buffer.from(expected, "hex");
+  const actualBuffer = Buffer.from(actual, "hex");
+
+  if (expectedBuffer.length !== actualBuffer.length) return false;
+
+  return crypto.timingSafeEqual(expectedBuffer, actualBuffer);
+}
+
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function getHeader(req: StripeRequest, name: string): string | undefined {
+  const headers = req.headers || {};
+  return firstHeaderValue(headers[name.toLowerCase()] as string | string[] | undefined);
+}
+
+function rawBodyFromRequest(req: StripeRequest): string | null {
+  const requestWithRawBody = req as StripeRequest & { rawBody?: Buffer | string };
+
+  if (typeof requestWithRawBody.rawBody === "string") return requestWithRawBody.rawBody;
+  if (Buffer.isBuffer(requestWithRawBody.rawBody)) return requestWithRawBody.rawBody.toString("utf8");
+  if (typeof req.body === "string") return req.body;
+  if (Buffer.isBuffer(req.body)) return req.body.toString("utf8");
+  if (req.body && typeof req.body === "object") return JSON.stringify(req.body);
+
+  return null;
+}
+
+function objectId(value: string | { id?: string } | null | undefined): string | null {
+  if (!value) return null;
+  if (typeof value === "string") return value;
+  return value.id || null;
+}
+
+function subscriptionIdFromEvent(event: StripeSupportedEvent): string | null {
+  const object = event.data.object;
+  if (event.type.indexOf("customer.subscription.") === 0) return (object as StripeSubscription).id || null;
+
+  return objectId((object as StripeInvoice).subscription as string | StripeSubscription | null | undefined);
+}
+
+function invoiceIdFromEvent(event: StripeSupportedEvent): string | null {
+  return event.type.indexOf("invoice.") === 0 ? ((event.data.object as StripeInvoice).id || null) : null;
+}
+
+export default class Stripe extends Askrift<"stripe"> {
+  private _req: StripeRequest;
+  private _webhookSecret: string;
+  private _event: StripeEvent | null = null;
+
+  constructor(req: StripeRequest, debugged?: boolean) {
+    super(debugged);
+    if (!process.env.STRIPE_WEBHOOK_SECRET) throw "STRIPE_WEBHOOK_SECRET is required";
+    this._req = req;
+    this._webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  }
+
+  onSubscriptionCreated(): Promise<StripeCustomerSubscriptionCreatedEvent | null> {
+    return this.eventForType<StripeCustomerSubscriptionCreatedEvent>("customer.subscription.created");
+  }
+
+  onSubscriptionCanceled(): Promise<StripeCustomerSubscriptionDeletedEvent | null> {
+    return this.eventForType<StripeCustomerSubscriptionDeletedEvent>("customer.subscription.deleted");
+  }
+
+  onSubscriptionUpdated(): Promise<StripeCustomerSubscriptionUpdatedEvent | null> {
+    return this.eventForType<StripeCustomerSubscriptionUpdatedEvent>("customer.subscription.updated");
+  }
+
+  onPaymentSucceeded(): Promise<StripeInvoicePaymentSucceededEvent | null> {
+    return this.eventForType<StripeInvoicePaymentSucceededEvent>("invoice.payment_succeeded");
+  }
+
+  onPaymentFailed(): Promise<StripeInvoicePaymentFailedEvent | null> {
+    return this.eventForType<StripeInvoicePaymentFailedEvent>("invoice.payment_failed");
+  }
+
+  onPaymentRefunded(): Promise<null> {
+    return Promise.resolve(null);
+  }
+
+  validRequest(): boolean {
+    const contentType = getHeader(this._req, "content-type") || "";
+    return this._req.method === "POST" && contentType.indexOf("application/json") >= 0;
+  }
+
+  validPayload(): boolean {
+    try {
+      const event = this.parseEvent();
+      return isStripeSupportedEventType(event.type);
+    } catch (error) {
+      this.debug(error);
+      return false;
+    }
+  }
+
+  verifySignature(toleranceInSeconds: number = 300): boolean {
+    const signatureHeader = getHeader(this._req, "stripe-signature");
+    const rawBody = rawBodyFromRequest(this._req);
+
+    if (!signatureHeader || !rawBody) return false;
+
+    const signatureParts = signatureHeader.split(",").reduce<Record<string, string[]>>((memo, part) => {
+      const separatorIndex = part.indexOf("=");
+      if (separatorIndex < 0) return memo;
+
+      const key = part.slice(0, separatorIndex);
+      const value = part.slice(separatorIndex + 1);
+      memo[key] = memo[key] || [];
+      memo[key].push(value);
+      return memo;
+    }, {});
+
+    const timestamp = signatureParts.t && signatureParts.t[0];
+    const signatures = signatureParts.v1 || [];
+    if (!timestamp || signatures.length === 0) return false;
+
+    const timestampNumber = Number(timestamp);
+    if (!Number.isFinite(timestampNumber)) return false;
+
+    if (toleranceInSeconds > 0) {
+      const age = Math.abs(Math.floor(Date.now() / 1000) - timestampNumber);
+      if (age > toleranceInSeconds) return false;
+    }
+
+    const signedPayload = `${timestamp}.${rawBody}`;
+    const expectedSignature = crypto
+      .createHmac("sha256", this._webhookSecret)
+      .update(signedPayload, "utf8")
+      .digest("hex");
+
+    return signatures.some((signature) => timingSafeEqual(expectedSignature, signature));
+  }
+
+  parseEvent(): StripeEvent {
+    if (this._event) return this._event;
+    if (!this.verifySignature()) throw new Error("Invalid Stripe signature");
+
+    const rawBody = rawBodyFromRequest(this._req);
+    if (!rawBody) throw new Error("Invalid Stripe body");
+
+    const parsed = JSON.parse(rawBody) as StripeEvent;
+    if (!parsed || parsed.object !== "event" || typeof parsed.type !== "string") {
+      throw new Error("Invalid Stripe event");
+    }
+
+    this._event = parsed;
+    return parsed;
+  }
+
+  getNormalizedEvent(): NormalizedStripeEvent | null {
+    const event = this.parseEvent();
+    if (!isStripeSupportedEventType(event.type)) return null;
+
+    const supportedEvent = event as StripeSupportedEvent;
+    const object = supportedEvent.data.object;
+
+    return {
+      provider: "stripe",
+      type: NORMALIZED_TYPES[supportedEvent.type],
+      eventId: supportedEvent.id,
+      eventType: supportedEvent.type,
+      created: new Date(supportedEvent.created * 1000),
+      customerId: objectId((object as StripeSubscription | StripeInvoice).customer),
+      subscriptionId: subscriptionIdFromEvent(supportedEvent),
+      invoiceId: invoiceIdFromEvent(supportedEvent),
+      data: object,
+      raw: supportedEvent,
+    };
+  }
+
+  private eventForType<T extends StripeSupportedEvent>(type: StripeSupportedEventType): Promise<T | null> {
+    try {
+      const event = this.parseEvent();
+      return Promise.resolve(event.type === type ? (event as T) : null);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -4,10 +4,9 @@ import { SUBSCRIPTION_EVENT_TYPES } from "../types/events";
 import type { NormalizedSubscriptionEvent, SubscriptionEventType } from "../types/events";
 import { fromRaw } from "./request";
 import type { InternalRequest } from "./request";
-import { extractStableEventId, isEventFresh } from "./idempotency";
+import { extractEventTimestamp, extractStableEventId, isEventFresh } from "./idempotency";
 import type { EventTimestampValidationOptions, NormalizedWebhookEvent } from "./idempotency";
 import type {
-  NormalizedStripeEvent,
   StripeCustomerSubscriptionCreatedEvent,
   StripeCustomerSubscriptionDeletedEvent,
   StripeCustomerSubscriptionUpdatedEvent,
@@ -168,29 +167,53 @@ export default class Stripe extends Askrift<"stripe"> {
     const object = supportedEvent.data.object;
     const normalizedType = NORMALIZED_TYPE_MAP[supportedEvent.type];
 
-    return {
+    const eventDate = new Date(supportedEvent.created * 1000);
+    const baseEvent: Record<string, unknown> = {
       type: normalizedType,
       provider: "stripe",
       eventId: supportedEvent.id,
       eventType: supportedEvent.type,
-      occurredAt: new Date(supportedEvent.created * 1000),
+      occurredAt: eventDate,
       customerId: objectId((object as StripeSubscription | StripeInvoice).customer),
       subscriptionId: subscriptionIdFromEvent(supportedEvent),
       invoiceId: invoiceIdFromEvent(supportedEvent),
       raw: supportedEvent,
-    } as unknown as NormalizedSubscriptionEvent;
+    };
+    Object.defineProperties(baseEvent, {
+      getIdempotencyKey: {
+        configurable: true,
+        enumerable: false,
+        value: () => {
+          const eventId = extractStableEventId("stripe", supportedEvent);
+          return eventId ? `stripe:${eventId}` : null;
+        },
+      },
+      getEventTimestamp: {
+        configurable: true,
+        enumerable: false,
+        value: () => extractEventTimestamp("stripe", supportedEvent),
+      },
+      isFresh: {
+        configurable: true,
+        enumerable: false,
+        value: (options: EventTimestampValidationOptions) =>
+          isEventFresh("stripe", supportedEvent, options),
+      },
+    });
+    return baseEvent as unknown as NormalizedSubscriptionEvent<unknown>;
   }
 
   getIdempotencyKey(): string | null {
     if (!this.verify()) return null;
     const event = this.parseStripeEvent();
-    return extractStableEventId("stripe", event);
+    const eventId = extractStableEventId("stripe", event);
+    return eventId ? `stripe:${eventId}` : null;
   }
 
   getEventTimestamp(): Date | null {
     if (!this.verify()) return null;
     const event = this.parseStripeEvent();
-    return new Date(event.created * 1000);
+    return extractEventTimestamp("stripe", event);
   }
 
   isFresh(options: EventTimestampValidationOptions): boolean | null {
@@ -201,6 +224,20 @@ export default class Stripe extends Askrift<"stripe"> {
 
   isSupportedEventType(type: string): boolean {
     return isStripeSupportedEventType(type);
+  }
+
+  protected parseProviderEvent(): import("./askrift").AskriftParsedEvent | null {
+    if (!this.verify()) return null;
+    const event = this.parseStripeEvent();
+    if (!isStripeSupportedEventType(event.type)) return null;
+    const normalizedType = NORMALIZED_TYPE_MAP[event.type];
+    return {
+      eventType: normalizedType,
+      payload: event as unknown as import("./askrift").AskriftParsedEvent["payload"],
+      provider: "stripe",
+      providerEventType: event.type,
+      aliases: [event.type],
+    };
   }
 
   verifySignature(toleranceInSeconds: number = 300): boolean {

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -39,10 +39,9 @@ function isStripeSupportedEventType(type: string): type is StripeSupportedEventT
 }
 
 function timingSafeEqual(expected: string, actual: string): boolean {
+  if (expected.length !== actual.length) return false;
   const expectedBuffer = Buffer.from(expected, "hex");
   const actualBuffer = Buffer.from(actual, "hex");
-
-  if (expectedBuffer.length !== actualBuffer.length) return false;
 
   return crypto.timingSafeEqual(expectedBuffer, actualBuffer);
 }
@@ -93,7 +92,7 @@ export default class Stripe extends Askrift<"stripe"> {
 
   constructor(req: StripeRequest, debugged?: boolean) {
     super(debugged);
-    if (!process.env.STRIPE_WEBHOOK_SECRET) throw "STRIPE_WEBHOOK_SECRET is required";
+    if (!process.env.STRIPE_WEBHOOK_SECRET) throw new Error("STRIPE_WEBHOOK_SECRET is required");
     this._req = req;
     this._webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
   }
@@ -147,8 +146,8 @@ export default class Stripe extends Askrift<"stripe"> {
       const separatorIndex = part.indexOf("=");
       if (separatorIndex < 0) return memo;
 
-      const key = part.slice(0, separatorIndex);
-      const value = part.slice(separatorIndex + 1);
+      const key = part.slice(0, separatorIndex).trim();
+      const value = part.slice(separatorIndex + 1).trim();
       memo[key] = memo[key] || [];
       memo[key].push(value);
       return memo;
@@ -212,12 +211,8 @@ export default class Stripe extends Askrift<"stripe"> {
     };
   }
 
-  private eventForType<T extends StripeSupportedEvent>(type: StripeSupportedEventType): Promise<T | null> {
-    try {
-      const event = this.parseEvent();
-      return Promise.resolve(event.type === type ? (event as T) : null);
-    } catch (error) {
-      return Promise.reject(error);
-    }
+  private async eventForType<T extends StripeSupportedEvent>(type: StripeSupportedEventType): Promise<T | null> {
+    const event = this.parseEvent();
+    return event.type === type ? (event as T) : null;
   }
 }

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -223,7 +223,9 @@ export default class Stripe extends Askrift<"stripe"> {
   }
 
   private async eventForType<T extends StripeSupportedEvent>(type: StripeSupportedEventType): Promise<T | null> {
-    const event = this.parseEvent();
+    const rawBody = rawBodyFromRequest(this._req);
+    if (!rawBody) throw new Error("Invalid Stripe body");
+    const event = JSON.parse(rawBody) as StripeEvent;
     return event.type === type ? (event as T) : null;
   }
 }

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -133,6 +133,7 @@ export default class Stripe extends Askrift<"stripe"> {
   }
 
   validPayload(): boolean {
+    if (!this.verifySignature()) return false;
     try {
       const event = this.parseEvent();
       return isStripeSupportedEventType(event.type);
@@ -140,6 +141,10 @@ export default class Stripe extends Askrift<"stripe"> {
       this.debug(error);
       return false;
     }
+  }
+
+  isSupportedEventType(type: string): boolean {
+    return isStripeSupportedEventType(type);
   }
 
   verifySignature(toleranceInSeconds: number = 300): boolean {

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -223,9 +223,12 @@ export default class Stripe extends Askrift<"stripe"> {
   }
 
   private async eventForType<T extends StripeSupportedEvent>(type: StripeSupportedEventType): Promise<T | null> {
-    const rawBody = rawBodyFromRequest(this._req);
-    if (!rawBody) throw new Error("Invalid Stripe body");
-    const event = JSON.parse(rawBody) as StripeEvent;
-    return event.type === type ? (event as T) : null;
+    try {
+      const event = this.parseEvent();
+      return event.type === type ? (event as T) : null;
+    } catch (error) {
+      this.debug(error);
+      return null;
+    }
   }
 }

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -40,9 +40,15 @@ function isStripeSupportedEventType(type: string): type is StripeSupportedEventT
 
 function timingSafeEqual(expected: string, actual: string): boolean {
   if (expected.length !== actual.length) return false;
-  const expectedBuffer = Buffer.from(expected, "hex");
-  const actualBuffer = Buffer.from(actual, "hex");
-
+  let expectedBuffer: Buffer;
+  let actualBuffer: Buffer;
+  try {
+    expectedBuffer = Buffer.from(expected, "hex");
+    actualBuffer = Buffer.from(actual, "hex");
+  } catch {
+    return false;
+  }
+  if (expectedBuffer.length !== actualBuffer.length) return false;
   return crypto.timingSafeEqual(expectedBuffer, actualBuffer);
 }
 

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,8 +1,13 @@
-import { VercelRequest } from "@vercel/node";
-import { Request } from "express";
 import * as crypto from "crypto";
 import Askrift from "./askrift";
-import {
+import { SUBSCRIPTION_EVENT_TYPES } from "../types/events";
+import type { SubscriptionEventType } from "../types/events";
+import { fromRaw } from "./request";
+import type { InternalRequest } from "./request";
+import { extractStableEventId, isEventFresh } from "./idempotency";
+import type { EventTimestampValidationOptions, NormalizedWebhookEvent } from "./idempotency";
+import type { NormalizedSubscriptionEvent } from "../types/events";
+import type {
   NormalizedStripeEvent,
   StripeCustomerSubscriptionCreatedEvent,
   StripeCustomerSubscriptionDeletedEvent,
@@ -15,6 +20,21 @@ import {
   StripeSupportedEvent,
   StripeSupportedEventType,
 } from "../types/stripe";
+  StripeCustomerSubscriptionDeletedEvent,
+  StripeCustomerSubscriptionUpdatedEvent,
+  StripeEvent,
+  StripeInvoice,
+  StripeInvoicePaymentFailedEvent,
+  StripeInvoicePaymentSucceededEvent,
+  StripeSubscription,
+  StripeSupportedEvent,
+  StripeSupportedEventType,
+} from "../types/stripe";
+
+export type StripeOptions = {
+  publicKey?: string;
+  debug?: boolean;
+};
 
 const SUPPORTED_EVENTS: StripeSupportedEventType[] = [
   "customer.subscription.created",
@@ -24,18 +44,16 @@ const SUPPORTED_EVENTS: StripeSupportedEventType[] = [
   "invoice.payment_failed",
 ];
 
-const NORMALIZED_TYPES: Record<StripeSupportedEventType, NormalizedStripeEvent["type"]> = {
-  "customer.subscription.created": "subscription.created",
-  "customer.subscription.updated": "subscription.updated",
-  "customer.subscription.deleted": "subscription.deleted",
-  "invoice.payment_succeeded": "payment.succeeded",
-  "invoice.payment_failed": "payment.failed",
+const NORMALIZED_TYPE_MAP: Record<StripeSupportedEventType, SubscriptionEventType> = {
+  "customer.subscription.created": SUBSCRIPTION_EVENT_TYPES.SubscriptionCreated,
+  "customer.subscription.updated": SUBSCRIPTION_EVENT_TYPES.SubscriptionUpdated,
+  "customer.subscription.deleted": SUBSCRIPTION_EVENT_TYPES.SubscriptionCancelled,
+  "invoice.payment_succeeded": SUBSCRIPTION_EVENT_TYPES.PaymentSucceeded,
+  "invoice.payment_failed": SUBSCRIPTION_EVENT_TYPES.PaymentFailed,
 };
 
-type StripeRequest = VercelRequest | Request;
-
-function isStripeSupportedEventType(type: string): type is StripeSupportedEventType {
-  return SUPPORTED_EVENTS.indexOf(type as StripeSupportedEventType) >= 0;
+function isStripeSupportedEventType(type: string | undefined): type is StripeSupportedEventType {
+  return typeof type === "string" && (SUPPORTED_EVENTS as string[]).includes(type);
 }
 
 function timingSafeEqual(expected: string, actual: string): boolean {
@@ -57,20 +75,23 @@ function firstHeaderValue(value: string | string[] | undefined): string | undefi
   return value;
 }
 
-function getHeader(req: StripeRequest, name: string): string | undefined {
-  const headers = req.headers || {};
+function getHeader(headers: Record<string, string | string[] | undefined> | undefined, name: string): string | undefined {
+  if (!headers) return undefined;
   return firstHeaderValue(headers[name.toLowerCase()] as string | string[] | undefined);
 }
 
-function rawBodyFromRequest(req: StripeRequest): string | null {
-  const requestWithRawBody = req as StripeRequest & { rawBody?: Buffer | string };
-
-  if (typeof requestWithRawBody.rawBody === "string") return requestWithRawBody.rawBody;
-  if (Buffer.isBuffer(requestWithRawBody.rawBody)) return requestWithRawBody.rawBody.toString("utf8");
+function rawBodyFromInternal(req: InternalRequest): string | null {
+  if (typeof req.rawBody === "string") return req.rawBody;
+  if (Buffer.isBuffer(req.rawBody)) return req.rawBody.toString("utf8");
   if (typeof req.body === "string") return req.body;
   if (Buffer.isBuffer(req.body)) return req.body.toString("utf8");
-  if (req.body && typeof req.body === "object") return JSON.stringify(req.body);
-
+  if (req.body && typeof req.body === "object") {
+    try {
+      return JSON.stringify(req.body);
+    } catch {
+      return null;
+    }
+  }
   return null;
 }
 
@@ -82,8 +103,9 @@ function objectId(value: string | { id?: string } | null | undefined): string | 
 
 function subscriptionIdFromEvent(event: StripeSupportedEvent): string | null {
   const object = event.data.object;
-  if (event.type.indexOf("customer.subscription.") === 0) return (object as StripeSubscription).id || null;
-
+  if (event.type.indexOf("customer.subscription.") === 0) {
+    return (object as StripeSubscription).id || null;
+  }
   return objectId((object as StripeInvoice).subscription as string | StripeSubscription | null | undefined);
 }
 
@@ -92,35 +114,39 @@ function invoiceIdFromEvent(event: StripeSupportedEvent): string | null {
 }
 
 export default class Stripe extends Askrift<"stripe"> {
-  private _req: StripeRequest;
+  private _req: InternalRequest;
   private _webhookSecret: string;
-  private _event: StripeEvent | null = null;
+  private _parsedEvent: StripeEvent | null = null;
+  private _verified: boolean | null = null;
 
-  constructor(req: StripeRequest, debugged?: boolean) {
-    super(debugged);
-    if (!process.env.STRIPE_WEBHOOK_SECRET) throw new Error("STRIPE_WEBHOOK_SECRET is required");
-    this._req = req;
-    this._webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  constructor(req: InternalRequest, options: StripeOptions | boolean = {}) {
+    const stripeOptions = typeof options === "boolean" ? { debug: options } : options;
+    super(stripeOptions.debug);
+    this._req = fromRaw(req);
+    this._webhookSecret = process.env.STRIPE_WEBHOOK_SECRET || "";
+    if (!this._webhookSecret) {
+      throw new Error("STRIPE_WEBHOOK_SECRET is required");
+    }
   }
 
-  onSubscriptionCreated(): Promise<StripeCustomerSubscriptionCreatedEvent | null> {
-    return this.eventForType<StripeCustomerSubscriptionCreatedEvent>("customer.subscription.created");
+  onSubscriptionCreated(): Promise<(SubscriptionCreated & NormalizedWebhookEvent) | null> {
+    return this.getProviderEventForType("customer.subscription.created");
   }
 
-  onSubscriptionCanceled(): Promise<StripeCustomerSubscriptionDeletedEvent | null> {
-    return this.eventForType<StripeCustomerSubscriptionDeletedEvent>("customer.subscription.deleted");
+  onSubscriptionCanceled(): Promise<(SubscriptionCancelled & NormalizedWebhookEvent) | null> {
+    return this.getProviderEventForType("customer.subscription.deleted");
   }
 
-  onSubscriptionUpdated(): Promise<StripeCustomerSubscriptionUpdatedEvent | null> {
-    return this.eventForType<StripeCustomerSubscriptionUpdatedEvent>("customer.subscription.updated");
+  onSubscriptionUpdated(): Promise<(SubscriptionUpdated & NormalizedWebhookEvent) | null> {
+    return this.getProviderEventForType("customer.subscription.updated");
   }
 
-  onPaymentSucceeded(): Promise<StripeInvoicePaymentSucceededEvent | null> {
-    return this.eventForType<StripeInvoicePaymentSucceededEvent>("invoice.payment_succeeded");
+  onPaymentSucceeded(): Promise<(PaymentSucceeded & NormalizedWebhookEvent) | null> {
+    return this.getProviderEventForType("invoice.payment_succeeded");
   }
 
-  onPaymentFailed(): Promise<StripeInvoicePaymentFailedEvent | null> {
-    return this.eventForType<StripeInvoicePaymentFailedEvent>("invoice.payment_failed");
+  onPaymentFailed(): Promise<(PaymentFailed & NormalizedWebhookEvent) | null> {
+    return this.getProviderEventForType("invoice.payment_failed");
   }
 
   onPaymentRefunded(): Promise<null> {
@@ -128,19 +154,60 @@ export default class Stripe extends Askrift<"stripe"> {
   }
 
   validRequest(): boolean {
-    const contentType = getHeader(this._req, "content-type") || "";
-    return this._req.method === "POST" && contentType.indexOf("application/json") >= 0;
+    const contentType = getHeader(this._req.headers, "content-type") || "";
+    return (this._req.method || "").toUpperCase() === "POST" && contentType.indexOf("application/json") >= 0;
   }
 
-  validPayload(): boolean {
-    if (!this.verifySignature()) return false;
-    try {
-      const event = this.parseEvent();
-      return isStripeSupportedEventType(event.type);
-    } catch (error) {
-      this.debug(error);
-      return false;
-    }
+  verify(): boolean {
+    if (this._verified !== null) return this._verified;
+    this._verified = this.verifySignature();
+    return this._verified;
+  }
+
+  getEventType(): SubscriptionEventType | null {
+    if (!this.verify()) return null;
+    const event = this.parseEvent();
+    if (!isStripeSupportedEventType(event.type)) return null;
+    return NORMALIZED_TYPE_MAP[event.type];
+  }
+
+  toNormalizedEvent(): NormalizedSubscriptionEvent | null {
+    if (!this.verify()) return null;
+    const event = this.parseEvent();
+    if (!isStripeSupportedEventType(event.type)) return null;
+    const supportedEvent = event as StripeSupportedEvent;
+    const object = supportedEvent.data.object;
+    const normalizedType = NORMALIZED_TYPE_MAP[supportedEvent.type];
+
+    return {
+      type: normalizedType,
+      provider: "stripe",
+      eventId: supportedEvent.id,
+      eventType: supportedEvent.type,
+      occurredAt: new Date(supportedEvent.created * 1000),
+      customerId: objectId((object as StripeSubscription | StripeInvoice).customer),
+      subscriptionId: subscriptionIdFromEvent(supportedEvent),
+      invoiceId: invoiceIdFromEvent(supportedEvent),
+      raw: supportedEvent,
+    } as unknown as NormalizedSubscriptionEvent;
+  }
+
+  getIdempotencyKey(): string | null {
+    if (!this.verify()) return null;
+    const event = this.parseEvent();
+    return extractStableEventId("stripe", event);
+  }
+
+  getEventTimestamp(): Date | null {
+    if (!this.verify()) return null;
+    const event = this.parseEvent();
+    return new Date(event.created * 1000);
+  }
+
+  isFresh(options: EventTimestampValidationOptions): boolean | null {
+    if (!this.verify()) return null;
+    const event = this.parseEvent();
+    return isEventFresh("stripe", event, options);
   }
 
   isSupportedEventType(type: string): boolean {
@@ -148,15 +215,15 @@ export default class Stripe extends Askrift<"stripe"> {
   }
 
   verifySignature(toleranceInSeconds: number = 300): boolean {
-    const signatureHeader = getHeader(this._req, "stripe-signature");
-    const rawBody = rawBodyFromRequest(this._req);
+    const headers = this._req.headers || {};
+    const signatureHeader = getHeader(headers, "stripe-signature");
+    const rawBody = rawBodyFromInternal(this._req);
 
     if (!signatureHeader || !rawBody) return false;
 
     const signatureParts = signatureHeader.split(",").reduce<Record<string, string[]>>((memo, part) => {
       const separatorIndex = part.indexOf("=");
       if (separatorIndex < 0) return memo;
-
       const key = part.slice(0, separatorIndex).trim();
       const value = part.slice(separatorIndex + 1).trim();
       memo[key] = memo[key] || [];
@@ -185,11 +252,11 @@ export default class Stripe extends Askrift<"stripe"> {
     return signatures.some((signature) => timingSafeEqual(expectedSignature, signature));
   }
 
-  parseEvent(): StripeEvent {
-    if (this._event) return this._event;
+  private parseEvent(): StripeEvent {
+    if (this._parsedEvent) return this._parsedEvent;
     if (!this.verifySignature()) throw new Error("Invalid Stripe signature");
 
-    const rawBody = rawBodyFromRequest(this._req);
+    const rawBody = rawBodyFromInternal(this._req);
     if (!rawBody) throw new Error("Invalid Stripe body");
 
     const parsed = JSON.parse(rawBody) as StripeEvent;
@@ -197,38 +264,28 @@ export default class Stripe extends Askrift<"stripe"> {
       throw new Error("Invalid Stripe event");
     }
 
-    this._event = parsed;
+    this._parsedEvent = parsed;
     return parsed;
   }
 
-  getNormalizedEvent(): NormalizedStripeEvent | null {
-    const event = this.parseEvent();
-    if (!isStripeSupportedEventType(event.type)) return null;
-
-    const supportedEvent = event as StripeSupportedEvent;
-    const object = supportedEvent.data.object;
-
-    return {
-      provider: "stripe",
-      type: NORMALIZED_TYPES[supportedEvent.type],
-      eventId: supportedEvent.id,
-      eventType: supportedEvent.type,
-      created: new Date(supportedEvent.created * 1000),
-      customerId: objectId((object as StripeSubscription | StripeInvoice).customer),
-      subscriptionId: subscriptionIdFromEvent(supportedEvent),
-      invoiceId: invoiceIdFromEvent(supportedEvent),
-      data: object,
-      raw: supportedEvent,
-    };
-  }
-
-  private async eventForType<T extends StripeSupportedEvent>(type: StripeSupportedEventType): Promise<T | null> {
+  private async getProviderEventForType<T extends StripeSupportedEvent>(type: StripeSupportedEventType): Promise<(T & NormalizedSubscriptionEvent & NormalizedWebhookEvent) | null> {
     try {
       const event = this.parseEvent();
-      return event.type === type ? (event as T) : null;
+      if (event.type !== type) return null;
+      const eventWithType = event as T;
+      const baseEvent = this.toNormalizedEvent();
+      if (!baseEvent) return null;
+      return { ...eventWithType, ...baseEvent } as unknown as T & NormalizedSubscriptionEvent & NormalizedWebhookEvent;
     } catch (error) {
       this.debug(error);
       return null;
     }
   }
 }
+
+type SubscriptionCreated = StripeCustomerSubscriptionCreatedEvent;
+type SubscriptionUpdated = StripeCustomerSubscriptionUpdatedEvent;
+type SubscriptionCancelled = StripeCustomerSubscriptionDeletedEvent;
+type PaymentSucceeded = StripeInvoicePaymentSucceededEvent;
+type PaymentFailed = StripeInvoicePaymentFailedEvent;
+type NormalizedSubscriptionEvent = NormalizedStripeEvent;

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,25 +1,14 @@
 import * as crypto from "crypto";
 import Askrift from "./askrift";
 import { SUBSCRIPTION_EVENT_TYPES } from "../types/events";
-import type { SubscriptionEventType } from "../types/events";
+import type { NormalizedSubscriptionEvent, SubscriptionEventType } from "../types/events";
 import { fromRaw } from "./request";
 import type { InternalRequest } from "./request";
 import { extractStableEventId, isEventFresh } from "./idempotency";
 import type { EventTimestampValidationOptions, NormalizedWebhookEvent } from "./idempotency";
-import type { NormalizedSubscriptionEvent } from "../types/events";
 import type {
   NormalizedStripeEvent,
   StripeCustomerSubscriptionCreatedEvent,
-  StripeCustomerSubscriptionDeletedEvent,
-  StripeCustomerSubscriptionUpdatedEvent,
-  StripeEvent,
-  StripeInvoice,
-  StripeInvoicePaymentFailedEvent,
-  StripeInvoicePaymentSucceededEvent,
-  StripeSubscription,
-  StripeSupportedEvent,
-  StripeSupportedEventType,
-} from "../types/stripe";
   StripeCustomerSubscriptionDeletedEvent,
   StripeCustomerSubscriptionUpdatedEvent,
   StripeEvent,
@@ -129,24 +118,24 @@ export default class Stripe extends Askrift<"stripe"> {
     }
   }
 
-  onSubscriptionCreated(): Promise<(SubscriptionCreated & NormalizedWebhookEvent) | null> {
-    return this.getProviderEventForType("customer.subscription.created");
+  onSubscriptionCreated(): Promise<(NormalizedSubscriptionCreatedEvent & NormalizedWebhookEvent) | null> {
+    return this.getProviderEventForType("customer.subscription.created") as Promise<(NormalizedSubscriptionCreatedEvent & NormalizedWebhookEvent) | null>;
   }
 
-  onSubscriptionCanceled(): Promise<(SubscriptionCancelled & NormalizedWebhookEvent) | null> {
-    return this.getProviderEventForType("customer.subscription.deleted");
+  onSubscriptionCanceled(): Promise<(NormalizedSubscriptionCancelledEvent & NormalizedWebhookEvent) | null> {
+    return this.getProviderEventForType("customer.subscription.deleted") as Promise<(NormalizedSubscriptionCancelledEvent & NormalizedWebhookEvent) | null>;
   }
 
-  onSubscriptionUpdated(): Promise<(SubscriptionUpdated & NormalizedWebhookEvent) | null> {
-    return this.getProviderEventForType("customer.subscription.updated");
+  onSubscriptionUpdated(): Promise<(NormalizedSubscriptionUpdatedEvent & NormalizedWebhookEvent) | null> {
+    return this.getProviderEventForType("customer.subscription.updated") as Promise<(NormalizedSubscriptionUpdatedEvent & NormalizedWebhookEvent) | null>;
   }
 
-  onPaymentSucceeded(): Promise<(PaymentSucceeded & NormalizedWebhookEvent) | null> {
-    return this.getProviderEventForType("invoice.payment_succeeded");
+  onPaymentSucceeded(): Promise<(NormalizedPaymentSucceededEvent & NormalizedWebhookEvent) | null> {
+    return this.getProviderEventForType("invoice.payment_succeeded") as Promise<(NormalizedPaymentSucceededEvent & NormalizedWebhookEvent) | null>;
   }
 
-  onPaymentFailed(): Promise<(PaymentFailed & NormalizedWebhookEvent) | null> {
-    return this.getProviderEventForType("invoice.payment_failed");
+  onPaymentFailed(): Promise<(NormalizedPaymentFailedEvent & NormalizedWebhookEvent) | null> {
+    return this.getProviderEventForType("invoice.payment_failed") as Promise<(NormalizedPaymentFailedEvent & NormalizedWebhookEvent) | null>;
   }
 
   onPaymentRefunded(): Promise<null> {
@@ -166,14 +155,14 @@ export default class Stripe extends Askrift<"stripe"> {
 
   getEventType(): SubscriptionEventType | null {
     if (!this.verify()) return null;
-    const event = this.parseEvent();
+    const event = this.parseStripeEvent();
     if (!isStripeSupportedEventType(event.type)) return null;
     return NORMALIZED_TYPE_MAP[event.type];
   }
 
-  toNormalizedEvent(): NormalizedSubscriptionEvent | null {
+  toNormalizedEvent(): NormalizedSubscriptionEvent<unknown> | null {
     if (!this.verify()) return null;
-    const event = this.parseEvent();
+    const event = this.parseStripeEvent();
     if (!isStripeSupportedEventType(event.type)) return null;
     const supportedEvent = event as StripeSupportedEvent;
     const object = supportedEvent.data.object;
@@ -194,19 +183,19 @@ export default class Stripe extends Askrift<"stripe"> {
 
   getIdempotencyKey(): string | null {
     if (!this.verify()) return null;
-    const event = this.parseEvent();
+    const event = this.parseStripeEvent();
     return extractStableEventId("stripe", event);
   }
 
   getEventTimestamp(): Date | null {
     if (!this.verify()) return null;
-    const event = this.parseEvent();
+    const event = this.parseStripeEvent();
     return new Date(event.created * 1000);
   }
 
   isFresh(options: EventTimestampValidationOptions): boolean | null {
     if (!this.verify()) return null;
-    const event = this.parseEvent();
+    const event = this.parseStripeEvent();
     return isEventFresh("stripe", event, options);
   }
 
@@ -252,7 +241,7 @@ export default class Stripe extends Askrift<"stripe"> {
     return signatures.some((signature) => timingSafeEqual(expectedSignature, signature));
   }
 
-  private parseEvent(): StripeEvent {
+  private parseStripeEvent(): StripeEvent {
     if (this._parsedEvent) return this._parsedEvent;
     if (!this.verifySignature()) throw new Error("Invalid Stripe signature");
 
@@ -268,14 +257,11 @@ export default class Stripe extends Askrift<"stripe"> {
     return parsed;
   }
 
-  private async getProviderEventForType<T extends StripeSupportedEvent>(type: StripeSupportedEventType): Promise<(T & NormalizedSubscriptionEvent & NormalizedWebhookEvent) | null> {
+  private async getProviderEventForType<T extends NormalizedSubscriptionEvent<unknown> = NormalizedSubscriptionEvent<unknown>>(type: StripeSupportedEventType): Promise<(T & NormalizedWebhookEvent) | null> {
     try {
-      const event = this.parseEvent();
-      if (event.type !== type) return null;
-      const eventWithType = event as T;
       const baseEvent = this.toNormalizedEvent();
-      if (!baseEvent) return null;
-      return { ...eventWithType, ...baseEvent } as unknown as T & NormalizedSubscriptionEvent & NormalizedWebhookEvent;
+      if (!baseEvent || baseEvent.type !== NORMALIZED_TYPE_MAP[type]) return null;
+      return baseEvent as unknown as (T & NormalizedWebhookEvent);
     } catch (error) {
       this.debug(error);
       return null;
@@ -283,9 +269,8 @@ export default class Stripe extends Askrift<"stripe"> {
   }
 }
 
-type SubscriptionCreated = StripeCustomerSubscriptionCreatedEvent;
-type SubscriptionUpdated = StripeCustomerSubscriptionUpdatedEvent;
-type SubscriptionCancelled = StripeCustomerSubscriptionDeletedEvent;
-type PaymentSucceeded = StripeInvoicePaymentSucceededEvent;
-type PaymentFailed = StripeInvoicePaymentFailedEvent;
-type NormalizedSubscriptionEvent = NormalizedStripeEvent;
+type NormalizedSubscriptionCreatedEvent = StripeCustomerSubscriptionCreatedEvent;
+type NormalizedSubscriptionUpdatedEvent = StripeCustomerSubscriptionUpdatedEvent;
+type NormalizedSubscriptionCancelledEvent = StripeCustomerSubscriptionDeletedEvent;
+type NormalizedPaymentSucceededEvent = StripeInvoicePaymentSucceededEvent;
+type NormalizedPaymentFailedEvent = StripeInvoicePaymentFailedEvent;

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -21,6 +21,12 @@ import type {
 
 export type StripeOptions = {
   publicKey?: string;
+  /**
+   * The webhook signing secret. If omitted, falls back to
+   * `process.env.STRIPE_WEBHOOK_SECRET`. The constructor throws if neither
+   * is set.
+   */
+  webhookSecret?: string;
   debug?: boolean;
 };
 
@@ -46,15 +52,11 @@ function isStripeSupportedEventType(type: string | undefined): type is StripeSup
 
 function timingSafeEqual(expected: string, actual: string): boolean {
   if (expected.length !== actual.length) return false;
-  let expectedBuffer: Buffer;
-  let actualBuffer: Buffer;
-  try {
-    expectedBuffer = Buffer.from(expected, "hex");
-    actualBuffer = Buffer.from(actual, "hex");
-  } catch {
-    return false;
-  }
-  if (expectedBuffer.length !== actualBuffer.length) return false;
+  if (!/^[0-9a-f]+$/i.test(expected) || !/^[0-9a-f]+$/i.test(actual)) return false;
+
+  const expectedBuffer = Buffer.from(expected, "hex");
+  const actualBuffer = Buffer.from(actual, "hex");
+
   return crypto.timingSafeEqual(expectedBuffer, actualBuffer);
 }
 
@@ -108,10 +110,10 @@ export default class Stripe extends Askrift<"stripe"> {
   private _verified: boolean | null = null;
 
   constructor(req: InternalRequest, options: StripeOptions | boolean = {}) {
-    const stripeOptions = typeof options === "boolean" ? { debug: options } : options;
+    const stripeOptions = typeof options === 'boolean' ? { debug: options } : options;
     super(stripeOptions.debug);
     this._req = fromRaw(req);
-    this._webhookSecret = process.env.STRIPE_WEBHOOK_SECRET || "";
+    this._webhookSecret = stripeOptions.webhookSecret || process.env.STRIPE_WEBHOOK_SECRET || "";
     if (!this._webhookSecret) {
       throw new Error("STRIPE_WEBHOOK_SECRET is required");
     }

--- a/src/types/stripe/event.ts
+++ b/src/types/stripe/event.ts
@@ -8,7 +8,7 @@ export type StripeSupportedEventType =
 export type StripeNormalizedEventType =
   | "subscription.created"
   | "subscription.updated"
-  | "subscription.deleted"
+  | "subscription.cancelled"
   | "payment.succeeded"
   | "payment.failed";
 
@@ -97,16 +97,3 @@ export type StripeSupportedEvent =
   | StripeCustomerSubscriptionDeletedEvent
   | StripeInvoicePaymentSucceededEvent
   | StripeInvoicePaymentFailedEvent;
-
-export interface NormalizedStripeEvent<T = any> {
-  provider: "stripe";
-  type: StripeNormalizedEventType;
-  eventId: string;
-  eventType: StripeSupportedEventType;
-  created: Date;
-  customerId: string | null;
-  subscriptionId: string | null;
-  invoiceId: string | null;
-  data: T;
-  raw: StripeSupportedEvent;
-}

--- a/src/types/stripe/event.ts
+++ b/src/types/stripe/event.ts
@@ -1,0 +1,112 @@
+export type StripeSupportedEventType =
+  | "customer.subscription.created"
+  | "customer.subscription.updated"
+  | "customer.subscription.deleted"
+  | "invoice.payment_succeeded"
+  | "invoice.payment_failed";
+
+export type StripeNormalizedEventType =
+  | "subscription.created"
+  | "subscription.updated"
+  | "subscription.deleted"
+  | "payment.succeeded"
+  | "payment.failed";
+
+export interface StripeEvent<T = any> {
+  id: string;
+  object: "event";
+  api_version?: string;
+  created: number;
+  data: {
+    object: T;
+    previous_attributes?: Record<string, any>;
+  };
+  livemode: boolean;
+  pending_webhooks?: number;
+  request?: {
+    id?: string | null;
+    idempotency_key?: string | null;
+  } | null;
+  type: string;
+}
+
+export interface StripeSubscription {
+  id: string;
+  object: "subscription";
+  customer: string | StripeCustomer;
+  status?: string;
+  current_period_end?: number;
+  current_period_start?: number;
+  cancel_at_period_end?: boolean;
+  canceled_at?: number | null;
+  cancel_at?: number | null;
+  ended_at?: number | null;
+  items?: Record<string, any>;
+  metadata?: Record<string, string>;
+  [key: string]: any;
+}
+
+export interface StripeInvoice {
+  id: string;
+  object: "invoice";
+  customer: string | StripeCustomer | null;
+  subscription?: string | StripeSubscription | null;
+  amount_due?: number;
+  amount_paid?: number;
+  amount_remaining?: number;
+  currency?: string;
+  hosted_invoice_url?: string | null;
+  invoice_pdf?: string | null;
+  status?: string;
+  metadata?: Record<string, string>;
+  [key: string]: any;
+}
+
+export interface StripeCustomer {
+  id: string;
+  object: "customer";
+  email?: string | null;
+  name?: string | null;
+  metadata?: Record<string, string>;
+  [key: string]: any;
+}
+
+export type StripeCustomerSubscriptionCreatedEvent = StripeEvent<StripeSubscription> & {
+  type: "customer.subscription.created";
+};
+
+export type StripeCustomerSubscriptionUpdatedEvent = StripeEvent<StripeSubscription> & {
+  type: "customer.subscription.updated";
+};
+
+export type StripeCustomerSubscriptionDeletedEvent = StripeEvent<StripeSubscription> & {
+  type: "customer.subscription.deleted";
+};
+
+export type StripeInvoicePaymentSucceededEvent = StripeEvent<StripeInvoice> & {
+  type: "invoice.payment_succeeded";
+};
+
+export type StripeInvoicePaymentFailedEvent = StripeEvent<StripeInvoice> & {
+  type: "invoice.payment_failed";
+};
+
+export type StripeSupportedEvent =
+  | StripeCustomerSubscriptionCreatedEvent
+  | StripeCustomerSubscriptionUpdatedEvent
+  | StripeCustomerSubscriptionDeletedEvent
+  | StripeInvoicePaymentSucceededEvent
+  | StripeInvoicePaymentFailedEvent;
+
+export interface NormalizedStripeEvent<T = any> {
+  provider: "stripe";
+  type: StripeNormalizedEventType;
+  eventId: string;
+  eventType: StripeSupportedEventType;
+  created: Date;
+  customerId: string | null;
+  subscriptionId: string | null;
+  invoiceId: string | null;
+  data: T;
+  raw: StripeSupportedEvent;
+}

--- a/src/types/stripe/index.ts
+++ b/src/types/stripe/index.ts
@@ -1,0 +1,1 @@
+export * from "./event";

--- a/tests/fixtures/stripe.ts
+++ b/tests/fixtures/stripe.ts
@@ -1,0 +1,72 @@
+import * as crypto from "crypto";
+
+export const stripeWebhookSecret = "whsec_test_secret";
+export const invalidStripeSignature = "bad_signature";
+
+export const stripeSubscriptionCreatedEvent = {
+  id: "evt_subscription_created",
+  object: "event",
+  created: 1620000000,
+  data: {
+    object: {
+      id: "sub_123",
+      object: "subscription",
+      customer: "cus_123",
+      status: "active",
+    },
+  },
+  livemode: false,
+  type: "customer.subscription.created",
+};
+
+export const stripeUnsupportedEvent = {
+  id: "evt_unsupported",
+  object: "event",
+  created: 1620000000,
+  data: {
+    object: {
+      id: "pi_123",
+      object: "payment_intent",
+      customer: "cus_123",
+    },
+  },
+  livemode: false,
+  type: "payment_intent.succeeded",
+};
+
+export const stripeInvoicePaymentSucceededEvent = {
+  id: "evt_invoice_paid",
+  object: "event",
+  created: 1620000100,
+  data: {
+    object: {
+      id: "in_123",
+      object: "invoice",
+      customer: "cus_123",
+      subscription: "sub_123",
+      amount_paid: 2000,
+      currency: "usd",
+      status: "paid",
+    },
+  },
+  livemode: false,
+  type: "invoice.payment_succeeded",
+};
+
+export function buildStripeRequest(event: Record<string, any>, signature?: string): any {
+  const body = JSON.stringify(event);
+  const timestamp = Math.floor(Date.now() / 1000);
+  const validSignature = crypto
+    .createHmac("sha256", stripeWebhookSecret)
+    .update(`${timestamp}.${body}`, "utf8")
+    .digest("hex");
+
+  return {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "stripe-signature": `t=${timestamp},v1=${signature || validSignature}`,
+    },
+    body,
+  };
+}

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -447,9 +447,9 @@ describe('provider registry initialization', function () {
 
   it('throws UnsupportedProviderError for unsupported providers', () => {
     assert.throws(
-      () => initialize('stripe' as any, fromVercel(createReq('POST'))),
+      () => initialize('unknown' as any, fromVercel(createReq('POST'))),
       UnsupportedProviderError,
-      'Unsupported provider: stripe'
+      'Unsupported provider: unknown'
     );
   });
 

--- a/tests/stripe.ts
+++ b/tests/stripe.ts
@@ -14,6 +14,10 @@ describe("library works with stripe", function () {
     process.env.STRIPE_WEBHOOK_SECRET = stripeWebhookSecret;
   });
 
+  afterEach(() => {
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+  });
+
   it("should pass a valid signature", () => {
     const askrift = initialize("stripe", buildStripeRequest(stripeSubscriptionCreatedEvent));
 

--- a/tests/stripe.ts
+++ b/tests/stripe.ts
@@ -33,17 +33,18 @@ describe("library works with stripe", function () {
   });
 
   it("should reject an unsupported event", () => {
-    const askrift = initialize("stripe", buildStripeRequest(stripeUnsupportedEvent));
+    const askrift = initialize("stripe", buildStripeRequest(stripeUnsupportedEvent)) as Stripe;
 
-    assert.equal(askrift.validPayload(), false);
+    assert.equal(askrift.validPayload(), true);
+    assert.equal(askrift.getEventType(), null);
   });
 
   it("should convert supported events to normalized events", async () => {
     const askrift = initialize("stripe", buildStripeRequest(stripeInvoicePaymentSucceededEvent)) as Stripe;
     const event = await askrift.onPaymentSucceeded();
-    const normalizedEvent = askrift.getNormalizedEvent();
+    const normalizedEvent = askrift.toNormalizedEvent() as any;
 
-    assert.equal(event?.type, "invoice.payment_succeeded");
+    assert.equal((event as any)?.type, "payment.succeeded");
     assert.equal(normalizedEvent?.provider, "stripe");
     assert.equal(normalizedEvent?.type, "payment.succeeded");
     assert.equal(normalizedEvent?.eventId, "evt_invoice_paid");

--- a/tests/stripe.ts
+++ b/tests/stripe.ts
@@ -52,4 +52,31 @@ describe("library works with stripe", function () {
     assert.equal(normalizedEvent?.subscriptionId, "sub_123");
     assert.equal(normalizedEvent?.invoiceId, "in_123");
   });
+
+  it("should dispatch handle() to the normalized event type", async () => {
+    const askrift = initialize("stripe", buildStripeRequest(stripeSubscriptionCreatedEvent)) as Stripe;
+    let receivedType: string | null = null;
+    askrift.on("subscription.created", () => {
+      receivedType = "subscription.created";
+    });
+    const result = await askrift.handle();
+    assert.equal(result.verified, true);
+    assert.equal(result.handled, true);
+    assert.equal(result.eventType, "subscription.created");
+    assert.equal(receivedType, "subscription.created");
+  });
+
+  it("should prefix the idempotency key with 'stripe:'", () => {
+    const askrift = initialize("stripe", buildStripeRequest(stripeSubscriptionCreatedEvent)) as Stripe;
+    const normalized = askrift.toNormalizedEvent() as any;
+    assert.equal(normalized.getIdempotencyKey(), "stripe:evt_subscription_created");
+  });
+
+  it("should treat Stripe's unix-seconds timestamp as seconds (not milliseconds)", () => {
+    const askrift = initialize("stripe", buildStripeRequest(stripeSubscriptionCreatedEvent)) as Stripe;
+    const normalized = askrift.toNormalizedEvent() as any;
+    const timestamp = normalized.getEventTimestamp();
+    assert.isOk(timestamp instanceof Date);
+    assert.equal(timestamp.getUTCFullYear() >= 2021, true);
+  });
 });

--- a/tests/stripe.ts
+++ b/tests/stripe.ts
@@ -1,0 +1,50 @@
+import { assert } from "chai";
+import { initialize, Stripe } from "../src";
+import {
+  buildStripeRequest,
+  invalidStripeSignature,
+  stripeInvoicePaymentSucceededEvent,
+  stripeSubscriptionCreatedEvent,
+  stripeUnsupportedEvent,
+  stripeWebhookSecret,
+} from "./fixtures/stripe";
+
+describe("library works with stripe", function () {
+  beforeEach(() => {
+    process.env.STRIPE_WEBHOOK_SECRET = stripeWebhookSecret;
+  });
+
+  it("should pass a valid signature", () => {
+    const askrift = initialize("stripe", buildStripeRequest(stripeSubscriptionCreatedEvent));
+
+    assert.equal(askrift.validRequest(), true);
+    assert.equal(askrift.validPayload(), true);
+  });
+
+  it("should reject an invalid signature", () => {
+    const askrift = initialize("stripe", buildStripeRequest(stripeSubscriptionCreatedEvent, invalidStripeSignature));
+
+    assert.equal(askrift.validRequest(), true);
+    assert.equal(askrift.validPayload(), false);
+  });
+
+  it("should reject an unsupported event", () => {
+    const askrift = initialize("stripe", buildStripeRequest(stripeUnsupportedEvent));
+
+    assert.equal(askrift.validPayload(), false);
+  });
+
+  it("should convert supported events to normalized events", async () => {
+    const askrift = initialize("stripe", buildStripeRequest(stripeInvoicePaymentSucceededEvent)) as Stripe;
+    const event = await askrift.onPaymentSucceeded();
+    const normalizedEvent = askrift.getNormalizedEvent();
+
+    assert.equal(event?.type, "invoice.payment_succeeded");
+    assert.equal(normalizedEvent?.provider, "stripe");
+    assert.equal(normalizedEvent?.type, "payment.succeeded");
+    assert.equal(normalizedEvent?.eventId, "evt_invoice_paid");
+    assert.equal(normalizedEvent?.customerId, "cus_123");
+    assert.equal(normalizedEvent?.subscriptionId, "sub_123");
+    assert.equal(normalizedEvent?.invoiceId, "in_123");
+  });
+});


### PR DESCRIPTION
### Motivation
- Add first-class Stripe webhook handling so the library can validate signatures, parse events and provide a normalized event shape like the existing Paddle provider.
- Support common subscription and invoice events and expose a consistent API for consumers to handle them.

### Description
- Add a new provider implementation at `src/lib/stripe.ts` that performs raw-body extraction, Stripe `stripe-signature` HMAC-SHA256 verification (with timestamp tolerance), event parsing, per-type handlers and a `getNormalizedEvent()` mapping.
- Add TypeScript types under `src/types/stripe/` (`event.ts`, `index.ts`) describing supported Stripe event shapes and the normalized event interface.
- Extend `TypesMap` in `src/lib/askrift.ts` and register `stripe` in the provider registry in `src/index.ts` so `initialize()` can construct a Stripe handler.
- Implement support for these Stripe events: `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.payment_succeeded`, and `invoice.payment_failed`, with normalized types mapped to `subscription.created/updated/deleted` and `payment.succeeded/failed`.
- Add tests and fixtures under `tests/fixtures/stripe.ts` and `tests/stripe.ts` covering valid signature, invalid signature, unsupported event, and normalized event conversion, and update `README.md` with initialization and handler examples including raw-body guidance.

### Testing
- Built the package with `npm run build` and the TypeScript compilation succeeded.
- Ran the Stripe unit tests with `mocha -r ts-node/register 'tests/stripe.ts'` and they passed (`4 passing`).
- Ran the full test suite with `npm test` and it failed because the existing Paddle tests require `PADDLE_PUBLIC_KEY` in the environment (test environment did not set this), so Stripe tests passed but the overall suite reported failures due to missing Paddle configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28c2d231a883298b5ea686f5e4d1eb)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ralphilius/askrift/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stripe webhook integration: signature verification, event normalization, and handlers for subscription and payment lifecycle events.

* **Documentation**
  * New concise Stripe setup guide with webhook configuration, raw payload guidance, and serverless handler examples; simplified "Supported Services" section.

* **Bug Fixes / Reliability**
  * Improved timestamp parsing and freshness checks across multiple providers for more consistent idempotency. 

* **Tests**
  * Added Stripe fixtures and expanded webhook integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->