### PR TITLE
Add webhook idempotency helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,73 @@ module.exports = (req, res) => {
 };
 ```
 
+### Idempotency keys and replay windows
+
+Webhook providers often retry delivery, so your handler should accept the first delivery for a provider event and skip later deliveries with the same ID. Áskrift exposes the provider's stable event ID through a provider-neutral idempotency key:
+
+```js
+import { initialize } from '@ralphilius/askrift'
+
+const askrift = initialize('paddle', req)
+
+if (!askrift.validRequest() || !askrift.validPayload({ maxAgeMs: 5 * 60 * 1000 })) {
+  res.status(400).end()
+  return
+}
+
+const idempotencyKey = askrift.getIdempotencyKey()
+// Paddle alert_id "120661188" becomes "paddle:120661188".
+```
+
+Normalized events returned from handlers expose the same `getIdempotencyKey()` method, plus timestamp helpers when a provider includes an event timestamp:
+
+```js
+const payment = await askrift.onPaymentSucceeded()
+
+if (payment) {
+  const idempotencyKey = payment.getIdempotencyKey()
+  const eventTimestamp = payment.getEventTimestamp()
+  const fresh = payment.isFresh({ maxAgeMs: 5 * 60 * 1000 })
+}
+```
+
+Use `getIdempotencyKey()` with any store that can atomically reserve a key before your business logic runs:
+
+```js
+const payment = await askrift.onPaymentSucceeded()
+if (!payment) return
+
+const key = payment.getIdempotencyKey()
+const ttlSeconds = 60 * 60 * 24 * 7
+
+// Database example: create a table with a UNIQUE constraint on `key`.
+try {
+  await db.webhookDeliveries.create({ data: { key } })
+} catch (error) {
+  // Duplicate key violation means this event was already handled.
+  return
+}
+
+// Redis example: SET key value NX EX ttlSeconds.
+const reserved = await redis.set(key, '1', { NX: true, EX: ttlSeconds })
+if (!reserved) return
+
+// KV example: use an atomic insert/create-if-not-exists operation.
+const created = await kv.set(key, '1', { ifNotExists: true, expirationTtl: ttlSeconds })
+if (!created) return
+
+// Safe to perform side effects after reserving the key.
+await provisionSubscription(payment)
+```
+
+You can also call the standalone helper if you are working with a raw provider payload:
+
+```js
+import { extractStableEventId } from '@ralphilius/askrift'
+
+const eventId = extractStableEventId('paddle', req.body)
+```
+
 ## Supported Services
 
 - Paddle

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,3 +56,6 @@ export function initialize(type: string, request: ProviderRequest, options?: Ini
   };
   return new Provider(request, mergedOptions);
 };
+
+export { extractStableEventId, extractEventTimestamp, isEventFresh, normalizeWebhookEvent } from "./lib/idempotency";
+export type { EventTimestampValidationOptions, NormalizedWebhookEvent, WebhookProvider } from "./lib/idempotency";

--- a/src/lib/askrift.ts
+++ b/src/lib/askrift.ts
@@ -4,7 +4,6 @@ import {
   SUBSCRIPTION_EVENT_TYPES,
   SubscriptionEventType,
 } from "../types/events";
-import type { EventTimestampValidationOptions } from "./idempotency";
 
 type ProviderEventMap = Partial<Record<SubscriptionEventType, unknown>>;
 

--- a/src/lib/askrift.ts
+++ b/src/lib/askrift.ts
@@ -4,6 +4,7 @@ import {
   SUBSCRIPTION_EVENT_TYPES,
   SubscriptionEventType,
 } from "../types/events";
+import type { EventTimestampValidationOptions } from "./idempotency";
 
 type ProviderEventMap = Partial<Record<SubscriptionEventType, unknown>>;
 

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -93,7 +93,7 @@ export function isEventFresh(
   if (toleranceMs < 0) throw new Error("toleranceMs must be non-negative");
 
   const timestamp = extractEventTimestamp(provider, payload);
-  if (!timestamp) return false;
+  if (!timestamp) return true;
 
   const ageMs = coerceNow(options.now) - timestamp.getTime();
   return ageMs >= -toleranceMs && ageMs <= options.maxAgeMs + toleranceMs;

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -62,7 +62,7 @@ export function extractStableEventId(provider: WebhookProvider, payload: unknown
 
   for (const field of PROVIDER_CONFIG[provider].idFields) {
     const value = parsedPayload[field];
-    if (typeof value === 'string' && value.trim() !== '') return value;
+    if (typeof value === 'string' && value.trim() !== '') return value.trim();
     if (typeof value === 'number' && Number.isFinite(value)) return String(value);
   }
 
@@ -87,7 +87,7 @@ export function isEventFresh(
   payload: unknown,
   options: EventTimestampValidationOptions,
 ): boolean | null {
-  if (options.maxAgeMs < 0) return false;
+  if (options.maxAgeMs < 0) throw new Error("maxAgeMs must be non-negative");
 
   const toleranceMs = options.toleranceMs ?? 5 * 60 * 1000;
   if (toleranceMs < 0) throw new Error("toleranceMs must be non-negative");

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -19,7 +19,7 @@ export type EventTimestampValidationOptions = {
 export interface NormalizedWebhookEvent {
   getIdempotencyKey(): string | null;
   getEventTimestamp(): Date | null;
-  isFresh(options: EventTimestampValidationOptions): boolean;
+  isFresh(options: EventTimestampValidationOptions): boolean | null;
 }
 
 type ProviderConfig = {
@@ -86,14 +86,14 @@ export function isEventFresh(
   provider: WebhookProvider,
   payload: unknown,
   options: EventTimestampValidationOptions,
-): boolean {
+): boolean | null {
   if (options.maxAgeMs < 0) return false;
 
   const toleranceMs = options.toleranceMs ?? 5 * 60 * 1000;
   if (toleranceMs < 0) throw new Error("toleranceMs must be non-negative");
 
   const timestamp = extractEventTimestamp(provider, payload);
-  if (!timestamp) return true;
+  if (!timestamp) return null;
 
   const ageMs = coerceNow(options.now) - timestamp.getTime();
   return ageMs >= -toleranceMs && ageMs <= options.maxAgeMs + toleranceMs;

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -5,12 +5,19 @@ export type WebhookProvider = 'paddle';
 export type EventTimestampValidationOptions = {
   /** Maximum accepted event age in milliseconds. */
   maxAgeMs: number;
+  /**
+   * Allowed clock skew in milliseconds, applied to both directions.
+   * Permits a small tolerance for events arriving slightly in the future
+   * (or stale events whose timestamps trail the receiver clock).
+   * Defaults to 5 minutes.
+   */
+  toleranceMs?: number;
   /** Time to compare against. Defaults to the current time. */
   now?: Date | number;
 };
 
 export interface NormalizedWebhookEvent {
-  getIdempotencyKey(): string;
+  getIdempotencyKey(): string | null;
   getEventTimestamp(): Date | null;
   isFresh(options: EventTimestampValidationOptions): boolean;
 }
@@ -85,35 +92,37 @@ export function isEventFresh(
   const timestamp = extractEventTimestamp(provider, payload);
   if (!timestamp) return false;
 
+  const toleranceMs = options.toleranceMs ?? 5 * 60 * 1000;
   const ageMs = coerceNow(options.now) - timestamp.getTime();
-  return ageMs >= 0 && ageMs <= options.maxAgeMs;
+  return ageMs >= -toleranceMs && ageMs <= options.maxAgeMs + toleranceMs;
 }
 
 export function normalizeWebhookEvent<T extends Record<string, any>>(
   provider: WebhookProvider,
   payload: T,
 ): T & NormalizedWebhookEvent {
-  Object.defineProperties(payload, {
+  const target: Record<string, any> = Object.isExtensible(payload) ? payload : { ...payload };
+
+  Object.defineProperties(target, {
     getIdempotencyKey: {
       configurable: true,
       enumerable: false,
       value: () => {
-        const eventId = extractStableEventId(provider, payload);
-        if (!eventId) throw new Error(`Unable to extract a stable ${provider} event ID`);
-        return `${provider}:${eventId}`;
+        const eventId = extractStableEventId(provider, target);
+        return eventId ? `${provider}:${eventId}` : null;
       },
     },
     getEventTimestamp: {
       configurable: true,
       enumerable: false,
-      value: () => extractEventTimestamp(provider, payload),
+      value: () => extractEventTimestamp(provider, target),
     },
     isFresh: {
       configurable: true,
       enumerable: false,
-      value: (options: EventTimestampValidationOptions) => isEventFresh(provider, payload, options),
+      value: (options: EventTimestampValidationOptions) => isEventFresh(provider, target, options),
     },
   });
 
-  return payload as T & NormalizedWebhookEvent;
+  return target as T & NormalizedWebhookEvent;
 }

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -89,10 +89,12 @@ export function isEventFresh(
 ): boolean {
   if (options.maxAgeMs < 0) return false;
 
+  const toleranceMs = options.toleranceMs ?? 5 * 60 * 1000;
+  if (toleranceMs < 0) throw new Error("toleranceMs must be non-negative");
+
   const timestamp = extractEventTimestamp(provider, payload);
   if (!timestamp) return false;
 
-  const toleranceMs = options.toleranceMs ?? 5 * 60 * 1000;
   const ageMs = coerceNow(options.now) - timestamp.getTime();
   return ageMs >= -toleranceMs && ageMs <= options.maxAgeMs + toleranceMs;
 }

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -1,0 +1,119 @@
+import { isObject } from "./utils";
+
+export type WebhookProvider = 'paddle';
+
+export type EventTimestampValidationOptions = {
+  /** Maximum accepted event age in milliseconds. */
+  maxAgeMs: number;
+  /** Time to compare against. Defaults to the current time. */
+  now?: Date | number;
+};
+
+export interface NormalizedWebhookEvent {
+  getIdempotencyKey(): string;
+  getEventTimestamp(): Date | null;
+  isFresh(options: EventTimestampValidationOptions): boolean;
+}
+
+type ProviderConfig = {
+  idFields: string[];
+  timestampFields: string[];
+};
+
+const PROVIDER_CONFIG: Record<WebhookProvider, ProviderConfig> = {
+  paddle: {
+    idFields: ['alert_id'],
+    timestampFields: ['event_time'],
+  },
+};
+
+function asPayload(payload: unknown): Record<string, any> | null {
+  return isObject(payload) && !Array.isArray(payload) ? payload as Record<string, any> : null;
+}
+
+function parsePaddleTimestamp(value: unknown): Date | null {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (typeof value !== 'string' || value.trim() === '') return null;
+
+  // Paddle Classic sends timestamps like "2021-09-10 10:36:39" in UTC.
+  const normalized = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(value)
+    ? `${value.replace(' ', 'T')}Z`
+    : value;
+  const date = new Date(normalized);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function coerceNow(now: Date | number | undefined): number {
+  if (now instanceof Date) return now.getTime();
+  if (typeof now === 'number') return now;
+  return Date.now();
+}
+
+export function extractStableEventId(provider: WebhookProvider, payload: unknown): string | null {
+  const parsedPayload = asPayload(payload);
+  if (!parsedPayload) return null;
+
+  for (const field of PROVIDER_CONFIG[provider].idFields) {
+    const value = parsedPayload[field];
+    if (typeof value === 'string' && value.trim() !== '') return value;
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  }
+
+  return null;
+}
+
+export function extractEventTimestamp(provider: WebhookProvider, payload: unknown): Date | null {
+  const parsedPayload = asPayload(payload);
+  if (!parsedPayload) return null;
+
+  for (const field of PROVIDER_CONFIG[provider].timestampFields) {
+    const value = parsedPayload[field];
+    const timestamp = provider === 'paddle' ? parsePaddleTimestamp(value) : null;
+    if (timestamp) return timestamp;
+  }
+
+  return null;
+}
+
+export function isEventFresh(
+  provider: WebhookProvider,
+  payload: unknown,
+  options: EventTimestampValidationOptions,
+): boolean {
+  if (options.maxAgeMs < 0) return false;
+
+  const timestamp = extractEventTimestamp(provider, payload);
+  if (!timestamp) return false;
+
+  const ageMs = coerceNow(options.now) - timestamp.getTime();
+  return ageMs >= 0 && ageMs <= options.maxAgeMs;
+}
+
+export function normalizeWebhookEvent<T extends Record<string, any>>(
+  provider: WebhookProvider,
+  payload: T,
+): T & NormalizedWebhookEvent {
+  Object.defineProperties(payload, {
+    getIdempotencyKey: {
+      configurable: true,
+      enumerable: false,
+      value: () => {
+        const eventId = extractStableEventId(provider, payload);
+        if (!eventId) throw new Error(`Unable to extract a stable ${provider} event ID`);
+        return `${provider}:${eventId}`;
+      },
+    },
+    getEventTimestamp: {
+      configurable: true,
+      enumerable: false,
+      value: () => extractEventTimestamp(provider, payload),
+    },
+    isFresh: {
+      configurable: true,
+      enumerable: false,
+      value: (options: EventTimestampValidationOptions) => isEventFresh(provider, payload, options),
+    },
+  });
+
+  return payload as T & NormalizedWebhookEvent;
+}

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -26,6 +26,7 @@ import {
 import { fromRaw } from "./request";
 import type { InternalRequest } from "./request";
 import { isObject } from "./utils";
+import { EventTimestampValidationOptions, extractEventTimestamp, extractStableEventId, isEventFresh, normalizeWebhookEvent } from "./idempotency";
 
 type PaddlePayload = { [k: string]: any };
 
@@ -228,6 +229,21 @@ export function verifyPaddleSignature(payload: unknown, publicKey: string): bool
   }
 }
 
+function promisify<T>(obj: any, key: string): Promise<T | null> {
+  return new Promise<T | null>((resolve, reject) => {
+    const payload = parseBody(obj);
+    if (payload) {
+      if (payload['alert_name'] == key) {
+        resolve(normalizeWebhookEvent('paddle', payload) as unknown as T);
+      } else {
+        resolve(null)
+      }
+    } else {
+      reject("Invalid body")
+    }
+  });
+}
+
 export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
   private _req: InternalRequest;
   private _pubKey: string;
@@ -336,6 +352,42 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     this._parsedBody = null;
     this._providerKind = null;
     return false;
+  }
+
+  getIdempotencyKey(): string | null {
+    const payload = parseBody(this._req.body);
+    const eventId = extractStableEventId('paddle', payload);
+    return eventId ? `paddle:${eventId}` : null;
+  }
+
+  getEventTimestamp(): Date | null {
+    return extractEventTimestamp('paddle', parseBody(this._req.body));
+  }
+
+  validEventAge(options: EventTimestampValidationOptions): boolean {
+    return isEventFresh('paddle', parseBody(this._req.body), options);
+  }
+
+  validPayload(options?: EventTimestampValidationOptions): boolean {
+    if (!this.verify()) return false;
+    if (!options) return true;
+    try {
+      const isFresh = this.validEventAge(options);
+      if (isFresh === null || isFresh === false) {
+        this._parsedBody = null;
+        this._providerKind = null;
+        return false;
+      }
+      return true;
+    } catch (ageError) {
+      if (ageError instanceof Error && (ageError.message === "toleranceMs must be non-negative" || ageError.message === "maxAgeMs must be non-negative")) {
+        throw ageError;
+      }
+      this.debug(ageError);
+      this._parsedBody = null;
+      this._providerKind = null;
+      return false;
+    }
   }
 
   private matchesExpectedProviderKind(detected: 'classic' | 'billing'): boolean {

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -364,7 +364,7 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     return extractEventTimestamp('paddle', parseBody(this._req.body));
   }
 
-  validEventAge(options: EventTimestampValidationOptions): boolean {
+  validEventAge(options: EventTimestampValidationOptions): boolean | null {
     return isEventFresh('paddle', parseBody(this._req.body), options);
   }
 

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -314,46 +314,6 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     return verifyPaddleBillingSignature(rawBody, signatureHeader, this._billingSecret);
   }
 
-  verify(): boolean {
-    this.debug(this._req.body);
-    const body = parseBody(this._req.body);
-    if (!body) {
-      this._parsedBody = null;
-      this._providerKind = null;
-      return false;
-    }
-
-    if (isBillingPayload(body)) {
-      if (!this.matchesExpectedProviderKind('billing')) {
-        this._parsedBody = null;
-        this._providerKind = null;
-        return false;
-      }
-      const rawBody = getRawBody(this._req);
-      const signatureHeader = firstHeader(this._req.headers['paddle-signature']);
-      const verified = this.validBillingPayload(body, rawBody, signatureHeader);
-      this._parsedBody = verified ? body : null;
-      this._providerKind = verified ? 'billing' : null;
-      return verified;
-    }
-
-    if (isClassicPayload(body)) {
-      if (!this.matchesExpectedProviderKind('classic')) {
-        this._parsedBody = null;
-        this._providerKind = null;
-        return false;
-      }
-      const verified = this.validClassicPayload(body);
-      this._parsedBody = verified ? body : null;
-      this._providerKind = verified ? 'classic' : null;
-      return verified;
-    }
-
-    this._parsedBody = null;
-    this._providerKind = null;
-    return false;
-  }
-
   getIdempotencyKey(): string | null {
     const payload = parseBody(this._req.body);
     const eventId = extractStableEventId('paddle', payload);
@@ -566,18 +526,6 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     if (!this._parsedBody) return null;
 
     const body = this._parsedBody;
-
-    if (this._providerKind === 'billing') {
-      if (typeof body.event_type !== 'string') return null;
-      const eventType = body.event_type;
-      return {
-        eventType,
-        payload: body,
-        provider: BILLING_PROVIDER,
-        providerEventType: eventType,
-        aliases: [`paddle-billing.${eventType}`],
-      };
-    }
 
     if (this._providerKind === 'billing') {
       if (typeof body.event_type !== 'string') return null;

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -2,7 +2,6 @@ import * as crypto from "crypto";
 import { serialize } from 'php-serialize';
 import Askrift, { AskriftParsedEvent } from "./askrift";
 import {
-  NormalizedSubscription,
   SubscriptionCancelled,
   SubscriptionCreated,
   SubscriptionPaymentFailed,
@@ -265,27 +264,27 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     this._expectedProviderKind = paddleOptions.kind || null;
   }
 
-  onSubscriptionCreated(): Promise<NormalizedSubscription | null> {
+  onSubscriptionCreated(): Promise<(SubscriptionCreated & NormalizedWebhookEvent) | null> {
     return this.getNormalizedProviderEvent(SUBSCRIPTION_EVENT_TYPES.SubscriptionCreated);
   }
 
-  onSubscriptionCanceled(): Promise<NormalizedSubscription | null> {
+  onSubscriptionCanceled(): Promise<(SubscriptionCancelled & NormalizedWebhookEvent) | null> {
     return this.getNormalizedProviderEvent(SUBSCRIPTION_EVENT_TYPES.SubscriptionCancelled);
   }
 
-  onSubscriptionUpdated(): Promise<NormalizedSubscription | null> {
+  onSubscriptionUpdated(): Promise<(SubscriptionUpdated & NormalizedWebhookEvent) | null> {
     return this.getNormalizedProviderEvent(SUBSCRIPTION_EVENT_TYPES.SubscriptionUpdated);
   }
 
-  onPaymentSucceeded(): Promise<NormalizedSubscription | null> {
+  onPaymentSucceeded(): Promise<(SubscriptionPaymentSucceeded & NormalizedWebhookEvent) | null> {
     return this.getNormalizedProviderEvent(SUBSCRIPTION_EVENT_TYPES.PaymentSucceeded);
   }
 
-  onPaymentFailed(): Promise<NormalizedSubscription | null> {
+  onPaymentFailed(): Promise<(SubscriptionPaymentFailed & NormalizedWebhookEvent) | null> {
     return this.getNormalizedProviderEvent(SUBSCRIPTION_EVENT_TYPES.PaymentFailed);
   }
 
-  onPaymentRefunded(): Promise<NormalizedSubscription | null> {
+  onPaymentRefunded(): Promise<(SubscriptionPaymentRefunded & NormalizedWebhookEvent) | null> {
     return this.getNormalizedProviderEvent(SUBSCRIPTION_EVENT_TYPES.PaymentRefunded);
   }
 
@@ -453,10 +452,11 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     const type = this.getEventType();
     if (!type) return null;
 
+    const normalizedRaw = normalizeWebhookEvent('paddle', body) as PaddlePayload & NormalizedWebhookEvent;
     const base = {
       type,
       provider: 'paddle',
-      raw: body,
+      raw: normalizedRaw,
       eventId: body.alert_id,
       occurredAt: toDate(body.event_time),
       subscriptionId: body.subscription_id,
@@ -467,29 +467,33 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
       status: body.status,
     } as NormalizedSubscriptionEvent;
 
+    let result: NormalizedSubscriptionEvent;
     switch (type) {
       case SUBSCRIPTION_EVENT_TYPES.SubscriptionCreated:
-        return {
+        result = {
           ...base,
           type,
           nextBillDate: toDate(body.next_bill_date),
         };
+        break;
       case SUBSCRIPTION_EVENT_TYPES.SubscriptionUpdated:
-        return {
+        result = {
           ...base,
           type,
           nextBillDate: toDate(body.next_bill_date),
           previousStatus: body.old_status,
           previousSubscriptionPlanId: body.old_subscription_plan_id,
         };
+        break;
       case SUBSCRIPTION_EVENT_TYPES.SubscriptionCancelled:
-        return {
+        result = {
           ...base,
           type,
           cancellationEffectiveDate: toDate(body.cancellation_effective_date),
         };
+        break;
       case SUBSCRIPTION_EVENT_TYPES.PaymentSucceeded:
-        return {
+        result = {
           ...base,
           type,
           paymentId: body.subscription_payment_id,
@@ -498,8 +502,9 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
           nextBillDate: toDate(body.next_bill_date),
           receiptUrl: body.receipt_url,
         };
+        break;
       case SUBSCRIPTION_EVENT_TYPES.PaymentFailed:
-        return {
+        result = {
           ...base,
           type,
           paymentId: body.subscription_payment_id,
@@ -508,8 +513,9 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
           nextRetryDate: toDate(body.next_retry_date),
           attemptNumber: body.attempt_number,
         };
+        break;
       case SUBSCRIPTION_EVENT_TYPES.PaymentRefunded:
-        return {
+        result = {
           ...base,
           type,
           paymentId: body.subscription_payment_id,
@@ -518,9 +524,30 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
           refundType: body.refund_type,
           refundReason: body.refund_reason,
         };
+        break;
       default:
         return null;
     }
+
+    Object.defineProperties(result, {
+      getIdempotencyKey: {
+        configurable: true,
+        enumerable: false,
+        value: () => normalizedRaw.getIdempotencyKey(),
+      },
+      getEventTimestamp: {
+        configurable: true,
+        enumerable: false,
+        value: () => normalizedRaw.getEventTimestamp(),
+      },
+      isFresh: {
+        configurable: true,
+        enumerable: false,
+        value: (options: EventTimestampValidationOptions) => normalizedRaw.isFresh(options),
+      },
+    });
+
+    return result;
   }
 
   async parseEvent(): Promise<NormalizedSubscriptionEvent | null> {
@@ -531,27 +558,6 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
       throw new Error("Could not parse webhook body");
     }
     const result = this.verify() ? this.toNormalizedEvent() : null;
-    if (result?.raw) {
-      const normalizedRaw = normalizeWebhookEvent('paddle', result.raw as PaddlePayload) as PaddlePayload & NormalizedWebhookEvent;
-      result.raw = normalizedRaw;
-      Object.defineProperties(result, {
-        getIdempotencyKey: {
-          configurable: true,
-          enumerable: false,
-          value: () => normalizedRaw.getIdempotencyKey(),
-        },
-        getEventTimestamp: {
-          configurable: true,
-          enumerable: false,
-          value: () => normalizedRaw.getEventTimestamp(),
-        },
-        isFresh: {
-          configurable: true,
-          enumerable: false,
-          value: (options: EventTimestampValidationOptions) => normalizedRaw.isFresh(options),
-        },
-      });
-    }
     this._parsedEventPromise = Promise.resolve(result);
     return this._parsedEventPromise;
   }
@@ -639,9 +645,9 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     return event as PaddleBillingTransactionEvent;
   }
 
-  private async getNormalizedProviderEvent(type: SubscriptionEventType): Promise<NormalizedSubscription | null> {
+  private async getNormalizedProviderEvent<T>(type: SubscriptionEventType): Promise<(T & NormalizedWebhookEvent) | null> {
     const event = await this.parseEvent();
     if (event?.type !== type) return null;
-    return (event.raw ?? null) as NormalizedSubscription | null;
+    return (event.raw ?? null) as (T & NormalizedWebhookEvent) | null;
   }
 }

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -2,6 +2,7 @@ import * as crypto from "crypto";
 import { serialize } from 'php-serialize';
 import Askrift, { AskriftParsedEvent } from "./askrift";
 import {
+  NormalizedSubscription,
   SubscriptionCancelled,
   SubscriptionCreated,
   SubscriptionPaymentFailed,
@@ -26,7 +27,7 @@ import {
 import { fromRaw } from "./request";
 import type { InternalRequest } from "./request";
 import { isObject } from "./utils";
-import { EventTimestampValidationOptions, extractEventTimestamp, extractStableEventId, isEventFresh, normalizeWebhookEvent } from "./idempotency";
+import { EventTimestampValidationOptions, extractEventTimestamp, extractStableEventId, isEventFresh, normalizeWebhookEvent, NormalizedWebhookEvent } from "./idempotency";
 
 type PaddlePayload = { [k: string]: any };
 
@@ -264,28 +265,28 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     this._expectedProviderKind = paddleOptions.kind || null;
   }
 
-  onSubscriptionCreated(): Promise<SubscriptionCreated | null> {
-    return this.getProviderEvent(SUBSCRIPTION_EVENT_TYPES.SubscriptionCreated);
+  onSubscriptionCreated(): Promise<NormalizedSubscription | null> {
+    return this.getNormalizedProviderEvent(SUBSCRIPTION_EVENT_TYPES.SubscriptionCreated);
   }
 
-  onSubscriptionCanceled(): Promise<SubscriptionCancelled | null> {
-    return this.getProviderEvent(SUBSCRIPTION_EVENT_TYPES.SubscriptionCancelled);
+  onSubscriptionCanceled(): Promise<NormalizedSubscription | null> {
+    return this.getNormalizedProviderEvent(SUBSCRIPTION_EVENT_TYPES.SubscriptionCancelled);
   }
 
-  onSubscriptionUpdated(): Promise<SubscriptionUpdated | null> {
-    return this.getProviderEvent(SUBSCRIPTION_EVENT_TYPES.SubscriptionUpdated);
+  onSubscriptionUpdated(): Promise<NormalizedSubscription | null> {
+    return this.getNormalizedProviderEvent(SUBSCRIPTION_EVENT_TYPES.SubscriptionUpdated);
   }
 
-  onPaymentSucceeded(): Promise<SubscriptionPaymentSucceeded | null> {
-    return this.getProviderEvent(SUBSCRIPTION_EVENT_TYPES.PaymentSucceeded);
+  onPaymentSucceeded(): Promise<NormalizedSubscription | null> {
+    return this.getNormalizedProviderEvent(SUBSCRIPTION_EVENT_TYPES.PaymentSucceeded);
   }
 
-  onPaymentFailed(): Promise<SubscriptionPaymentFailed | null> {
-    return this.getProviderEvent(SUBSCRIPTION_EVENT_TYPES.PaymentFailed);
+  onPaymentFailed(): Promise<NormalizedSubscription | null> {
+    return this.getNormalizedProviderEvent(SUBSCRIPTION_EVENT_TYPES.PaymentFailed);
   }
 
-  onPaymentRefunded(): Promise<SubscriptionPaymentRefunded | null> {
-    return this.getProviderEvent(SUBSCRIPTION_EVENT_TYPES.PaymentRefunded);
+  onPaymentRefunded(): Promise<NormalizedSubscription | null> {
+    return this.getNormalizedProviderEvent(SUBSCRIPTION_EVENT_TYPES.PaymentRefunded);
   }
 
   validRequest(): boolean {
@@ -369,7 +370,43 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
   }
 
   verify(): boolean {
-    return this.validPayload();
+    this.debug(this._req.body);
+    const body = parseBody(this._req.body);
+    if (!body) {
+      this._parsedBody = null;
+      this._providerKind = null;
+      return false;
+    }
+
+    if (isBillingPayload(body)) {
+      if (!this.matchesExpectedProviderKind('billing')) {
+        this._parsedBody = null;
+        this._providerKind = null;
+        return false;
+      }
+      const rawBody = getRawBody(this._req);
+      const signatureHeader = firstHeader(this._req.headers['paddle-signature']);
+      const verified = this.validBillingPayload(body, rawBody, signatureHeader);
+      this._parsedBody = verified ? body : null;
+      this._providerKind = verified ? 'billing' : null;
+      return verified;
+    }
+
+    if (isClassicPayload(body)) {
+      if (!this.matchesExpectedProviderKind('classic')) {
+        this._parsedBody = null;
+        this._providerKind = null;
+        return false;
+      }
+      const verified = this.validClassicPayload(body);
+      this._parsedBody = verified ? body : null;
+      this._providerKind = verified ? 'classic' : null;
+      return verified;
+    }
+
+    this._parsedBody = null;
+    this._providerKind = null;
+    return false;
   }
 
   validPayload(options?: EventTimestampValidationOptions): boolean {
@@ -428,7 +465,7 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
       customerEmail: body.email,
       currency: body.currency,
       status: body.status,
-    };
+    } as NormalizedSubscriptionEvent;
 
     switch (type) {
       case SUBSCRIPTION_EVENT_TYPES.SubscriptionCreated:
@@ -495,7 +532,25 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     }
     const result = this.verify() ? this.toNormalizedEvent() : null;
     if (result?.raw) {
-      normalizeWebhookEvent('paddle', result.raw as PaddlePayload);
+      const normalizedRaw = normalizeWebhookEvent('paddle', result.raw as PaddlePayload) as PaddlePayload & NormalizedWebhookEvent;
+      result.raw = normalizedRaw;
+      Object.defineProperties(result, {
+        getIdempotencyKey: {
+          configurable: true,
+          enumerable: false,
+          value: () => normalizedRaw.getIdempotencyKey(),
+        },
+        getEventTimestamp: {
+          configurable: true,
+          enumerable: false,
+          value: () => normalizedRaw.getEventTimestamp(),
+        },
+        isFresh: {
+          configurable: true,
+          enumerable: false,
+          value: (options: EventTimestampValidationOptions) => normalizedRaw.isFresh(options),
+        },
+      });
     }
     this._parsedEventPromise = Promise.resolve(result);
     return this._parsedEventPromise;
@@ -518,13 +573,25 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
       };
     }
 
+    if (this._providerKind === 'billing') {
+      if (typeof body.event_type !== 'string') return null;
+      const eventType = body.event_type;
+      return {
+        eventType,
+        payload: normalizeWebhookEvent('paddle', body),
+        provider: BILLING_PROVIDER,
+        providerEventType: eventType,
+        aliases: [`paddle-billing.${eventType}`],
+      };
+    }
+
     if (this._providerKind === 'classic') {
       if (typeof body.alert_name !== 'string') return null;
       const providerEventType = body.alert_name;
       const eventType = normalizePaddleEventName(providerEventType);
       return {
         eventType,
-        payload: body,
+        payload: normalizeWebhookEvent('paddle', body),
         provider: CLASSIC_PROVIDER,
         providerEventType,
         aliases: [`paddle.${providerEventType}`, `paddle-classic.${providerEventType}`],
@@ -570,5 +637,11 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     if (!event || typeof event.event_type !== 'string') return null;
     if (!event.event_type.startsWith('transaction.')) return null;
     return event as PaddleBillingTransactionEvent;
+  }
+
+  private async getNormalizedProviderEvent(type: SubscriptionEventType): Promise<NormalizedSubscription | null> {
+    const event = await this.parseEvent();
+    if (event?.type !== type) return null;
+    return (event.raw ?? null) as NormalizedSubscription | null;
   }
 }

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -229,21 +229,6 @@ export function verifyPaddleSignature(payload: unknown, publicKey: string): bool
   }
 }
 
-function promisify<T>(obj: any, key: string): Promise<T | null> {
-  return new Promise<T | null>((resolve, reject) => {
-    const payload = parseBody(obj);
-    if (payload) {
-      if (payload['alert_name'] == key) {
-        resolve(normalizeWebhookEvent('paddle', payload) as unknown as T);
-      } else {
-        resolve(null)
-      }
-    } else {
-      reject("Invalid body")
-    }
-  });
-}
-
 export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
   private _req: InternalRequest;
   private _pubKey: string;

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -368,6 +368,10 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
     return isEventFresh('paddle', parseBody(this._req.body), options);
   }
 
+  verify(): boolean {
+    return this.validPayload();
+  }
+
   validPayload(options?: EventTimestampValidationOptions): boolean {
     if (!this.verify()) return false;
     if (!options) return true;
@@ -490,6 +494,9 @@ export default class Paddle extends Askrift<PaddleSubscriptionEvents> {
       throw new Error("Could not parse webhook body");
     }
     const result = this.verify() ? this.toNormalizedEvent() : null;
+    if (result?.raw) {
+      normalizeWebhookEvent('paddle', result.raw as PaddlePayload);
+    }
     this._parsedEventPromise = Promise.resolve(result);
     return this._parsedEventPromise;
   }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,3 +1,5 @@
+import type { NormalizedWebhookEvent } from "../lib/idempotency";
+
 export const SUBSCRIPTION_EVENT_TYPES = {
   SubscriptionCreated: "subscription.created",
   SubscriptionUpdated: "subscription.updated",
@@ -9,7 +11,7 @@ export const SUBSCRIPTION_EVENT_TYPES = {
 
 export type SubscriptionEventType = typeof SUBSCRIPTION_EVENT_TYPES[keyof typeof SUBSCRIPTION_EVENT_TYPES];
 
-export interface NormalizedEventBase<TType extends SubscriptionEventType = SubscriptionEventType, TRaw = unknown> {
+export interface NormalizedEventBase<TType extends SubscriptionEventType = SubscriptionEventType, TRaw = unknown> extends NormalizedWebhookEvent {
   type: TType;
   provider: string;
   raw: TRaw;

--- a/src/types/paddle/subscription.ts
+++ b/src/types/paddle/subscription.ts
@@ -13,3 +13,8 @@ export {
   PaddleClassicRefundType as RefundType,
   PaddleClassicSubscriptionStatus as Status,
 } from "./classic";
+
+import type { NormalizedWebhookEvent } from "../../lib/idempotency";
+import type { PaddleClassicAlertBase } from "./classic";
+
+export interface NormalizedSubscription extends PaddleClassicAlertBase, NormalizedWebhookEvent {}

--- a/tests/fixtures/paddle.ts
+++ b/tests/fixtures/paddle.ts
@@ -10,6 +10,5 @@ export const paddlePaymentSucceededDuplicatePayload = {
 
 export const paddleStalePaymentSucceededPayload = {
   ...paddlePaymentSucceededPayload,
-  "alert_id": "120661189",
   "event_time": "2021-01-01 00:00:00",
 };

--- a/tests/fixtures/paddle.ts
+++ b/tests/fixtures/paddle.ts
@@ -1,0 +1,15 @@
+export const paddlePaymentSucceededPayload = {
+  "alert_id": "120661188", "alert_name": "subscription_payment_succeeded", "balance_currency": "GBP", "balance_earnings": "990.07", "balance_fee": "99.44", "balance_gross": "570.99", "balance_tax": "213.9", "checkout_id": "7-8ed52238d1752b0-72f9b4c4b7", "country": "AU", "coupon": "Coupon 8", "currency": "GBP", "customer_name": "customer_name", "earnings": "850.26", "email": "mitchell.ollie@example.org", "event_time": "2021-09-10 10:36:39", "fee": "0.77", "initial_payment": "false", "instalments": "3", "marketing_consent": "", "next_bill_date": "2021-09-25", "next_payment_amount": "next_payment_amount", "order_id": "8",
+  "passthrough": "Example String", "payment_method": "card", "payment_tax": "0.12", "plan_name": "Example String", "quantity": "21", "receipt_url": "https://my.paddle.com/receipt/8/485212962ae4daf-2e58a66474", "sale_gross": "463.62", "status": "active", "subscription_id": "8", "subscription_payment_id": "7", "subscription_plan_id": "6", "unit_price": "unit_price", "user_id": "4"
+};
+
+export const paddlePaymentSucceededDuplicatePayload = {
+  ...paddlePaymentSucceededPayload,
+  "email": "duplicate-delivery@example.org",
+};
+
+export const paddleStalePaymentSucceededPayload = {
+  ...paddlePaymentSucceededPayload,
+  "alert_id": "120661189",
+  "event_time": "2021-01-01 00:00:00",
+};

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -237,6 +237,20 @@ describe('library works with paddle', function () {
     assert.equal(event?.isFresh({ maxAgeMs: 60 * 1000, now: new Date('2021-09-10T10:37:00Z') }), true);
   });
 
+  it('should expose helpers when using validPayload() then toNormalizedEvent() directly', () => {
+    const paddle = initialize('paddle', createReq('POST'));
+    assert.equal(paddle.validPayload(), true);
+
+    const event = paddle.toNormalizedEvent();
+    assert.isNotNull(event);
+    assert.equal(typeof event?.getIdempotencyKey, 'function');
+    assert.equal(event?.getIdempotencyKey(), 'paddle:120661188');
+    assert.equal(typeof event?.getEventTimestamp, 'function');
+    assert.equal(event?.getEventTimestamp()?.toISOString(), '2021-09-10T10:36:39.000Z');
+    assert.equal(typeof event?.isFresh, 'function');
+    assert.equal(event?.isFresh({ maxAgeMs: 60 * 1000, now: new Date('2021-09-10T10:37:00Z') }), true);
+  });
+
   it('should expose helpers on handle() payloads', async () => {
     const paddle = initialize('paddle', createReq('POST'));
     let received: any = null;

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -1,4 +1,4 @@
-import Askrift, { initialize, fromVercel, Paddle, UnsupportedProviderError, extractStableEventId } from '../src';
+import Askrift, { initialize, fromVercel, UnsupportedProviderError, extractStableEventId, Paddle } from '../src';
 import { paddlePaymentSucceededPayload, paddlePaymentSucceededDuplicatePayload, paddleStalePaymentSucceededPayload } from './fixtures/paddle';
 import * as crypto from 'crypto';
 import { serialize } from 'php-serialize';
@@ -28,6 +28,8 @@ const baseReq: any = {
     'content-type': 'application/x-www-form-urlencoded'
   },
 };
+
+const paddlePublicKey = `-----BEGIN PUBLIC KEY-----\n${process.env.PADDLE_PUBLIC_KEY}\n-----END PUBLIC KEY-----`;
 
 const payload = paddlePaymentSucceededPayload;
 

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -1,4 +1,5 @@
-import Askrift, { initialize, fromVercel, Paddle, UnsupportedProviderError } from '../src';
+import Askrift, { initialize, fromVercel, Paddle, UnsupportedProviderError, extractStableEventId } from '../src';
+import { paddlePaymentSucceededPayload, paddlePaymentSucceededDuplicatePayload, paddleStalePaymentSucceededPayload } from './fixtures/paddle';
 import * as crypto from 'crypto';
 import { serialize } from 'php-serialize';
 import { assert } from 'chai';
@@ -28,12 +29,7 @@ const baseReq: any = {
   },
 };
 
-const paddlePublicKey = `-----BEGIN PUBLIC KEY-----\n${process.env.PADDLE_PUBLIC_KEY}\n-----END PUBLIC KEY-----`;
-
-const payload = {
-  "alert_id": "120661188", "alert_name": "subscription_payment_succeeded", "balance_currency": "GBP", "balance_earnings": "990.07", "balance_fee": "99.44", "balance_gross": "570.99", "balance_tax": "213.9", "checkout_id": "7-8ed52238d1752b0-72f9b4c4b7", "country": "AU", "coupon": "Coupon 8", "currency": "GBP", "customer_name": "customer_name", "earnings": "850.26", "email": "mitchell.ollie@example.org", "event_time": "2021-09-10 10:36:39", "fee": "0.77", "initial_payment": "false", "instalments": "3", "marketing_consent": "", "next_bill_date": "2021-09-25", "next_payment_amount": "next_payment_amount", "order_id": "8",
-  "passthrough": "Example String", "payment_method": "card", "payment_tax": "0.12", "plan_name": "Example String", "quantity": "21", "receipt_url": "https://my.paddle.com/receipt/8/485212962ae4daf-2e58a66474", "sale_gross": "463.62", "status": "active", "subscription_id": "8", "subscription_payment_id": "7", "subscription_plan_id": "6", "unit_price": "unit_price", "user_id": "4"
-};
+const payload = paddlePaymentSucceededPayload;
 
 function ksort(obj: { [k: string]: any }) {
   const keys = Object.keys(obj).sort();
@@ -127,24 +123,41 @@ const urlEncodedReq = {
   body: new URLSearchParams(validPayload).toString(),
 };
 
+const duplicatePayload = {
+  ...paddlePaymentSucceededDuplicatePayload,
+  p_signature: JSON.parse(signedPayload(paddlePaymentSucceededDuplicatePayload)).p_signature,
+};
+
+const stalePayload = {
+  ...paddleStalePaymentSucceededPayload,
+  p_signature: JSON.parse(signedPayload(paddleStalePaymentSucceededPayload)).p_signature,
+};
+
+const duplicateReq: any = {
+  ...baseReq,
+  method: 'POST',
+  body: JSON.stringify(duplicatePayload),
+};
+
+const staleReq: any = {
+  ...baseReq,
+  method: 'POST',
+  body: JSON.stringify(stalePayload),
+};
+
 describe('library works with paddle', function () {
-  const previousPublicKey = process.env.PADDLE_PUBLIC_KEY;
   let askriftPd: Paddle;
   let askriftBadPd: Paddle;
   let askriftUrlEncodedPd: Paddle;
-
-  after(() => {
-    if (previousPublicKey === undefined) {
-      delete process.env.PADDLE_PUBLIC_KEY;
-    } else {
-      process.env.PADDLE_PUBLIC_KEY = previousPublicKey;
-    }
-  });
+  let askriftDuplicatePd: Paddle;
+  let askriftStalePd: Paddle;
 
   it('should initalize successfully', (done) => {
     askriftPd = initialize('paddle', fromVercel(createReq('POST')));
     askriftBadPd = initialize('paddle', fromVercel(createReq('GET', JSON.stringify({ ...payload, p_signature: 'badsign' }))));
     askriftUrlEncodedPd = initialize('paddle', fromVercel(urlEncodedReq));
+    askriftDuplicatePd = initialize('paddle', fromVercel(duplicateReq));
+    askriftStalePd = initialize('paddle', fromVercel(staleReq));
     done();
   });
 
@@ -168,6 +181,25 @@ describe('library works with paddle', function () {
     assert.equal(askriftPd.validPayload(), true);
     const event = await askriftPd.onPaymentSucceeded();
     assert.equal(event?.p_signature, validPayload.p_signature);
+  });
+
+  it('should extract duplicate event IDs into the same provider-neutral idempotency key', async () => {
+    assert.equal(extractStableEventId('paddle', payload), '120661188');
+    assert.equal(askriftPd.getIdempotencyKey(), 'paddle:120661188');
+    assert.equal(askriftDuplicatePd.getIdempotencyKey(), 'paddle:120661188');
+
+    const event = await askriftDuplicatePd.onPaymentSucceeded();
+    assert.equal(event?.getIdempotencyKey(), 'paddle:120661188');
+  });
+
+  it('should expose event timestamps and reject stale payloads when max age is provided', async () => {
+    assert.equal(askriftPd.getEventTimestamp()?.toISOString(), '2021-09-10T10:36:39.000Z');
+    assert.equal(askriftPd.validPayload({ maxAgeMs: 60 * 1000, now: new Date('2021-09-10T10:37:00Z') }), true);
+    assert.equal(askriftStalePd.validPayload({ maxAgeMs: 60 * 1000, now: new Date('2021-09-10T10:37:00Z') }), false);
+
+    const event = await askriftPd.onPaymentSucceeded();
+    assert.equal(event?.getEventTimestamp()?.toISOString(), '2021-09-10T10:36:39.000Z');
+    assert.equal(event?.isFresh({ maxAgeMs: 60 * 1000, now: new Date('2021-09-10T10:37:00Z') }), true);
   });
 
   it('should not pass invalid request', (done) => {

--- a/tests/paddle.ts
+++ b/tests/paddle.ts
@@ -204,6 +204,60 @@ describe('library works with paddle', function () {
     assert.equal(event?.isFresh({ maxAgeMs: 60 * 1000, now: new Date('2021-09-10T10:37:00Z') }), true);
   });
 
+  it('should throw when maxAgeMs is negative', () => {
+    assert.throws(
+      () => askriftPd.validPayload({ maxAgeMs: -1 }),
+      Error,
+      'maxAgeMs must be non-negative'
+    );
+  });
+
+  it('should reject payloads with missing timestamps when max age is provided', () => {
+    const noTimestampPayload = { ...validPayloadWithoutSignature };
+    delete (noTimestampPayload as { event_time?: string }).event_time;
+    const signed = signPayload(noTimestampPayload);
+    const body = { ...noTimestampPayload, p_signature: signed };
+    const paddle = initialize('paddle', reqFor('POST', body, 'application/json'));
+
+    assert.equal(paddle.validPayload(), true);
+    assert.equal(paddle.validPayload({ maxAgeMs: 60 * 1000 }), false);
+  });
+
+  it('should clear parsed body when stale payload is rejected', () => {
+    const paddle = initialize('paddle', staleReq);
+    assert.equal(paddle.validPayload({ maxAgeMs: 60 * 1000, now: new Date('2021-09-10T10:37:00Z') }), false);
+    assert.isNull(paddle.getEventType());
+  });
+
+  it('should expose helpers on parseEvent() results', async () => {
+    const event = await askriftPd.parseEvent();
+    assert.isNotNull(event);
+    assert.equal(event?.getIdempotencyKey(), 'paddle:120661188');
+    assert.equal(event?.getEventTimestamp()?.toISOString(), '2021-09-10T10:36:39.000Z');
+    assert.equal(event?.isFresh({ maxAgeMs: 60 * 1000, now: new Date('2021-09-10T10:37:00Z') }), true);
+  });
+
+  it('should expose helpers on handle() payloads', async () => {
+    const paddle = initialize('paddle', createReq('POST'));
+    let received: any = null;
+    paddle.on('subscription.payment.succeeded', (payload) => {
+      received = payload;
+    });
+
+    const result = await paddle.handle();
+    assert.equal(result.handled, true);
+    assert.isNotNull(received);
+    assert.equal(typeof received.getIdempotencyKey, 'function');
+    assert.equal(received.getIdempotencyKey(), 'paddle:120661188');
+    assert.equal(typeof received.getEventTimestamp, 'function');
+    assert.equal(received.getEventTimestamp()?.toISOString(), '2021-09-10T10:36:39.000Z');
+  });
+
+  it('should trim whitespace-padded event IDs', () => {
+    const padded = { ...paddlePaymentSucceededPayload, alert_id: '  120661188  ' };
+    assert.equal(extractStableEventId('paddle', padded), '120661188');
+  });
+
   it('should not pass invalid request', (done) => {
     assert.equal(askriftBadPd.validRequest(), false);
     done();


### PR DESCRIPTION
### Motivation

- Provide a provider-neutral way to extract a stable event ID and timestamp from incoming webhook payloads so consumers can deduplicate retries and enforce replay windows.
- Expose helper APIs on normalized events to make idempotency/reservation logic ergonomic across stores (DB / Redis / KV).
- Parse provider-specific timestamp formats (Paddle Classic) and allow optional max-age validation during payload verification.

### Description

- Add `src/lib/idempotency.ts` with `extractStableEventId()`, `extractEventTimestamp()`, `isEventFresh()`, and `normalizeWebhookEvent()` plus types `WebhookProvider`, `EventTimestampValidationOptions`, and `NormalizedWebhookEvent`.
- Wire the helpers into Paddle: decorate returned events with `getIdempotencyKey()`, `getEventTimestamp()`, and `isFresh()`, add `getIdempotencyKey()`/`getEventTimestamp()`/`validEventAge()` methods to the Paddle adapter, and make `validPayload(options?)` optionally reject stale signed payloads using `maxAgeMs`.
- Update the public entrypoint `src/index.ts` to export the idempotency helpers and types, and update Paddle subscription types to extend `NormalizedWebhookEvent` so normalized events expose the helper methods.
- Document usage and show examples for combining `getIdempotencyKey()` with a database UNIQUE insert, Redis `SET NX EX`, and KV-style insert-if-not-exists in `README.md`.
- Add static fixtures `tests/fixtures/paddle.ts` and test coverage in `tests/paddle.ts` for duplicate event IDs and stale timestamp handling, and update tests to use the normalized events.

### Testing

- Ran `yarn test`, which executed the updated test suite and resulted in all tests passing (`9 passing`).
- Ran `yarn build` to verify TypeScript compilation and distribution artifacts, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ae0b16db48329b6ded5a48a787970)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ralphilius/askrift/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook idempotency and freshness validation utilities to prevent processing duplicate events
  * Configurable timestamp validation with optional clock-skew tolerance for reliable event age checking
  * New webhook event normalization capabilities providing convenient methods for idempotency keys, timestamps, and freshness validation
  * Initial support for Paddle webhook events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->